### PR TITLE
Allow empty passwords

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,13 @@
 class User < ApplicationRecord
-  has_secure_password
+  has_secure_password validations: false
 
   before_validation :downcase_email, on: [:create, :update]
 
   validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A[^@\s]+@([^@.\s]+\.)+[^@.\s]+\z/ }
   validates :first_name, :last_name, presence: true
-  validates :password, length: { minimum: PASSWORD_MIN_LENGTH }
+  validates :password, length: { minimum: PASSWORD_MIN_LENGTH },
+    confirmation: true,
+    allow_nil: true
 
   scope :admins, -> { where(admin: true) }
   scope :regular, -> { where(admin: false) }
@@ -16,6 +18,10 @@ class User < ApplicationRecord
 
   def full_name
     [first_name, last_name].join(" ")
+  end
+
+  def authenticate(given_password)
+    password_digest.present? && super
   end
 
   private

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,18 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "#authenticate will not authenticate user without password" do
+    user = FactoryBot.create(:user, password: nil, password_digest: nil)
+    refute user.authenticate("secret")
+  end
+
+  test "#authenticate will authenticate user with correct password" do
+    user = FactoryBot.create(:user)
+    assert user.authenticate("secret")
+  end
+
+  test "#authenticate will not authenticate when given wrong password" do
+    user = FactoryBot.create(:user)
+    refute user.authenticate("password")
+  end
 end


### PR DESCRIPTION
This allows users to be saved in the database _without a password_.

This is not a feature for hdm as is, but will be helpful in the future when implementing other authentication schemes that do not rely on a locally stored password.

Users with empty password will _not_ be authenticated, so they cannot login.

