### PR TITLE
Enforce authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   rescue_from Hdm::Error, with: :display_error_page
   rescue_from CanCan::AccessDenied, with: :access_denied
 
+  before_action :authentication_required
+
   helper_method :current_user
 
   private
@@ -13,6 +15,16 @@ class ApplicationController < ActionController::Base
 
     if session[:user_id]
       Current.user ||= User.find(session[:user_id])
+    end
+  end
+
+  def authentication_required
+    unless current_user
+      if User.none?
+        redirect_to new_user_path, notice: 'Please create an admin user first.'
+      else
+        redirect_to login_path
+      end
     end
   end
 

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -1,4 +1,6 @@
 class PageController < ApplicationController
+  skip_before_action :authentication_required
+
   add_breadcrumb "Home", :root_path
 
   def index

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :authentication_required
+
   add_breadcrumb "Home", :root_path
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  skip_before_action :authentication_required, only: [:new, :create]
+  before_action :conditional_authentication, only: [:new, :create]
+
   load_and_authorize_resource
   add_breadcrumb "Home", :root_path
 
@@ -83,5 +86,9 @@ class UsersController < ApplicationController
           params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
         end
       end
+    end
+
+    def conditional_authentication
+      authentication_required if User.exists?
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,7 +34,7 @@ class Ability
     if User.none?
       can :create, User
     else
-      user ||= User.new # guest user (not logged in)
+      return unless user.present?
 
       if user.admin?
         if User.admins.count > 1

--- a/test/integration/required_authentication_test.rb
+++ b/test/integration/required_authentication_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class RequiredAuthenticationTest < ActionDispatch::IntegrationTest
+
+  test "authentication requirements for environments" do
+    authentication_required_for :get, environments_path
+  end
+
+  test "authentication requiremens for nodes" do
+    authentication_required_for :get, environment_nodes_path("development")
+  end
+
+  test "authentication requirements for keys" do
+    authentication_required_for :get,
+      environment_node_keys_path("development", "testhost")
+    authentication_required_for :get,
+      environment_node_key_path("development", "testhost", "hdm::integer")
+    authentication_required_for :patch,
+      environment_node_key_path("development", "testhost", "hdm::integer")
+    authentication_required_for :delete,
+      environment_node_key_path("development", "testhost", "hdm::integer")
+  end
+
+  test "authentication requirements for decrypted values" do
+    authentication_required_for :post,
+      environment_node_decrypted_values_path("development", "testhost")
+  end
+
+  test "authentication requirements for encrypted values" do
+    authentication_required_for :post,
+      environment_node_encrypted_values_path("development", "testhost")
+  end
+
+  test "authentication requirements for users" do
+    user = FactoryBot.create(:user, admin: true)
+
+    authentication_required_for :get, users_path
+    authentication_required_for :get, user_path(user)
+    authentication_required_for :get, new_user_path
+    authentication_required_for :post, users_path
+    authentication_required_for :get, edit_user_path(user)
+    authentication_required_for :patch, user_path(user)
+    authentication_required_for :delete, user_path(user)
+  end
+
+  private
+
+  def authentication_required_for(method, path)
+    send(method, path)
+    assert_redirected_to login_path
+  end
+end


### PR DESCRIPTION
OK, this one is embarrassing.

Up until now, hdm never actually restricted access to hiera data from anonymous users. If you were not logged in, you could still access "internal" pages if you knew the URL.

This was due to a combination of reasons:

1.) Authorization is performed with the help of the `cancancan` gem. The rules live in `app/models/abilities.rb`. If no user was signed in, the following line simply created one:

https://github.com/betadots/hdm/blob/52d8487625430c05d7b8a74214c2bbfb3916a387/app/models/ability.rb#L37

So anonymous users had the same rights a regular user.

This PR changes that line, so anonymous (i.e. non-existent) users have **no** rights.

2.) It is customary in rails applications to check for signed in users in a so called `before_action` as the very first step when a request hits the application. This is so there is no need to query the authorization layer or waste other resources in these cases at all.

Such a `before_action` was missing from hdm.

This PR adds a `before_action` checking the authentication in `ApplicationController`, so _all_ controllers inherit it. In the few places where login is not required, exceptions to that rule have been added.

I am really sorry that I did not catch this earlier. I guess there were so many familiar patterns already in place that I just expected this to work :frowning_face: 