### PR TITLE
Do not run CI jobs twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@
 
 on:
   - pull_request
-  - push
 
 name: CI
 


### PR DESCRIPTION
This workaround was initially required to test the action in the PR
where it was added. It's not required anymore to run all jobs twice.