### PR TITLE
Add responsive breakpoints #18

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -12,6 +12,25 @@ $breadcrumb-padding-x: 0;
 $breadcrumb-font-size: .875em;
 $breadcrumb-bg: #fff;
 
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1400px,
+  xxxl: 1900px
+) !default;
+
+$container-max-widths: (
+  sm: 540px,
+  md: 720px,
+  lg: 960px,
+  xl: 1140px,
+  xxl: 1320px,
+  xxxl: 1540px
+) !default;
+
 @import "~bootstrap/scss/bootstrap";
 
 ol.breadcrumb li:first-child {


### PR DESCRIPTION
First attempt to solve #18. With this change you should have a considerably larger usable area on modern wide screens.

A bit of background:

Bootstrap is a "responsive" CSS framework, which means the width of the layout containers depends on the screen resolution. Bootstraps defines a couple of "breakpoints", pixel-widths of the browser's visible viewport. At those breakpoints, widths and other CSS attributes may change. You can easily see this, when making your browser window narrower. Things stay the same for while, but if you reach a certain window width, something changes.

We use Bootstrap 4, which defined 1200px as the largest breakpoint. So if your browser window reaches a width of 1200px, the layout containers have their maximum width. With modern screens usually offering a (virtual) pixel width of 1920, this leaves a lot of screen space unused.

Thus, Bootstrap 5 introduces another breakpoint at 1400px. I copied this, but also introduced yet another, even larger breakpoint at 1900px.

I think this works really well. Please have a look.

There is also an alternative: Instead of fixed-width containers that depend on breakpoints, Bootstrap also offers "fluid" containers that always use the maximum width available. Let me know, in case I should give this a try as well.