### PR TITLE
Interpolate facts with a `facts.` or `trusted.` scope #17

### DIFF
--- a/app/models/hiera_data/interpolation.rb
+++ b/app/models/hiera_data/interpolation.rb
@@ -10,14 +10,14 @@ class HieraData
     def interpolate_facts(path:, facts:)
       groups = path.scan(/%{([^}]+)}/)
       groups.flatten!
-      groups.each { |x| x.gsub!(/^::/, '')}
+      groups.each { |x| x.gsub!(/^(::|facts\.)/, '')}
 
       resolved_path = path.dup
 
       groups.each do |fact|
         facts_value = facts.dig(*fact.split("."))
         next unless facts_value
-        resolved_path.gsub!(/%{(::)?#{fact}}/, facts_value)
+        resolved_path.gsub!(/%{(::|facts\.)?#{fact}}/, facts_value)
       end
 
       resolved_path

--- a/test/fixtures/files/puppet/environments/development/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/development/hiera.yaml
@@ -6,8 +6,8 @@ defaults:
 hierarchy:
   - name: "Eyaml hierarchy"
     paths:
-      - "nodes/%{::fqdn}.yaml"
-      - "role/%{::role}-%{::env}.yaml"
-      - "role/%{::role}.yaml"
-      - "zone/%{::zone}.yaml"
+      - "nodes/%{::facts.fqdn}.yaml"
+      - "role/%{::facts.role}-%{::facts.env}.yaml"
+      - "role/%{::facts.role}.yaml"
+      - "zone/%{::facts.zone}.yaml"
       - "common.yaml"

--- a/test/fixtures/files/puppet/environments/eyaml/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/eyaml/hiera.yaml
@@ -8,13 +8,13 @@ defaults:
 
 hierarchy:
   - name: "Host specific"
-    path: "nodes/%{::fqdn}.yaml"
+    path: "nodes/%{::facts.fqdn}.yaml"
 
   - name: "Per-datacenter business group data" # Uses custom facts.
     paths:
-      - "role/%{::role}-%{::env}.yaml"
-      - "role/%{::role}.yaml"
-      - "zone/%{::zone}.yaml"
+      - "role/%{::facts.role}-%{::facts.env}.yaml"
+      - "role/%{::facts.role}.yaml"
+      - "zone/%{::facts.zone}.yaml"
 
   - name: "Global data"
     path: "common.yaml"

--- a/test/fixtures/files/puppet/environments/globs/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/globs/hiera.yaml
@@ -6,10 +6,10 @@ defaults:
 hierarchy:
   - name: "Eyaml hierarchy"
     paths:
-      - "nodes/%{::fqdn}.yaml"
-      - "role/%{::role}-%{::env}.yaml"
-      - "role/%{::role}.yaml"
-      - "zone/%{::zone}.yaml"
+      - "nodes/%{::facts.fqdn}.yaml"
+      - "role/%{::facts.role}-%{::facts.env}.yaml"
+      - "role/%{::facts.role}.yaml"
+      - "zone/%{::facts.zone}.yaml"
   - name: "Common"
     globs:
       - "common/*.yaml"

--- a/test/fixtures/files/puppet/environments/multiple_hierarchies/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/multiple_hierarchies/hiera.yaml
@@ -5,13 +5,13 @@ defaults:
 
 hierarchy:
   - name: "Host specific"
-    path: "nodes/%{::fqdn}.yaml"
+    path: "nodes/%{::facts.fqdn}.yaml"
 
   - name: "Per-datacenter business group data" # Uses custom facts.
     paths:
-      - "role/%{::role}-%{::env}.yaml"
-      - "role/%{::role}.yaml"
-      - "zone/%{::zone}.yaml"
+      - "role/%{::facts.role}-%{::facts.env}.yaml"
+      - "role/%{::facts.role}.yaml"
+      - "zone/%{::facts.zone}.yaml"
 
   - name: "Global data"
     path: "common.yaml"

--- a/test/fixtures/files/puppet/environments/test/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/test/hiera.yaml
@@ -6,8 +6,8 @@ defaults:
 hierarchy:
   - name: "Eyaml hierarchy"
     paths:
-      - "nodes/%{::fqdn}.yaml"
-      - "role/%{::role}-%{::env}.yaml"
-      - "role/%{::role}.yaml"
-      - "zone/%{::zone}.yaml"
+      - "nodes/%{::facts.fqdn}.yaml"
+      - "role/%{::facts.role}-%{::facts.env}.yaml"
+      - "role/%{::facts.role}.yaml"
+      - "zone/%{::facts.zone}.yaml"
       - "common.yaml"

--- a/test/models/hiera_data/hierarchy_test.rb
+++ b/test/models/hiera_data/hierarchy_test.rb
@@ -25,10 +25,10 @@ class HieraData::HierarchyTest < ActiveSupport::TestCase
   test "#paths returns all non-interpolated path names" do
     hierarchy = HieraData::Hierarchy.new(raw_hash: raw_hash, base_path: ".")
     expected_paths = [
-      "nodes/%{::fqdn}.yaml",
-      "role/%{::role}-%{::env}.yaml",
-      "role/%{::role}.yaml",
-      "zone/%{::zone}.yaml",
+      "nodes/%{::facts.fqdn}.yaml",
+      "role/%{::facts.role}-%{::facts.env}.yaml",
+      "role/%{::facts.role}.yaml",
+      "zone/%{::facts.zone}.yaml",
       "common.yaml"
     ]
     assert_equal expected_paths, hierarchy.paths
@@ -93,10 +93,10 @@ class HieraData::HierarchyTest < ActiveSupport::TestCase
     {
       "name" => "Yaml hierarchy",
       "paths" => [
-        "nodes/%{::fqdn}.yaml",
-        "role/%{::role}-%{::env}.yaml",
-        "role/%{::role}.yaml",
-        "zone/%{::zone}.yaml",
+        "nodes/%{::facts.fqdn}.yaml",
+        "role/%{::facts.role}-%{::facts.env}.yaml",
+        "role/%{::facts.role}.yaml",
+        "zone/%{::facts.zone}.yaml",
         "common.yaml"
       ]
     }

--- a/test/models/hiera_data/interpolation_test.rb
+++ b/test/models/hiera_data/interpolation_test.rb
@@ -13,7 +13,7 @@ class HieraData::InterpolationTest < ActiveSupport::TestCase
   end
 
   test "::interpolate_facts replaces facts with leading colons" do
-    path = "/test/%{::test_fact}/file"
+    path = "/test/%{::facts.test_fact}/file"
     facts = {"test_fact" => "replaced"}
     expected_result = "/test/replaced/file"
 
@@ -21,14 +21,6 @@ class HieraData::InterpolationTest < ActiveSupport::TestCase
   end
 
   test "::interpolate_facts replaces facts without leading colons" do
-    path = "/test/%{test_fact}/file"
-    facts = {"test_fact" => "replaced"}
-    expected_result = "/test/replaced/file"
-
-    assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
-  end
-
-  test "::interpolate_facts replaces facts with `facts.` scope" do
     path = "/test/%{facts.test_fact}/file"
     facts = {"test_fact" => "replaced"}
     expected_result = "/test/replaced/file"
@@ -36,11 +28,41 @@ class HieraData::InterpolationTest < ActiveSupport::TestCase
     assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
   end
 
+  test "::interpolate_facts replaces facts with `trusted.` scope with leading colons" do
+    path = "/test/%{::trusted.test_fact}/file"
+    facts = {"trusted" => {"test_fact" => "replaced"}}
+    expected_result = "/test/replaced/file"
+
+    assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
+  end
+
+  test "::interpolate_facts replaces facts with `trusted.` scope without leading colons" do
+    path = "/test/%{trusted.test_fact}/file"
+    facts = {"trusted" => {"test_fact" => "replaced"}}
+    expected_result = "/test/replaced/file"
+
+    assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
+  end
+
   test "::interpolate_facts replaces nested facts" do
-    path = "/test/%{nested.fact}/file"
+    path = "/test/%{facts.nested.fact}/file"
     facts = {"nested" => {"fact" => "deep"}}
     expected_result = "/test/deep/file"
 
     assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
+  end
+
+  test "::interpolate_facts will not replace arbitrary variables with leading colons" do
+    path = "/test/%{::test_fact}/file"
+    facts = {"test_fact" => "replaced"}
+
+    assert_equal path, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
+  end
+
+  test "::interpolate_facts will not replace arbitrary variables without leading colons" do
+    path = "/test/%{test_fact}/file"
+    facts = {"test_fact" => "replaced"}
+
+    assert_equal path, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
   end
 end

--- a/test/models/hiera_data/interpolation_test.rb
+++ b/test/models/hiera_data/interpolation_test.rb
@@ -28,6 +28,14 @@ class HieraData::InterpolationTest < ActiveSupport::TestCase
     assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
   end
 
+  test "::interpolate_facts replaces facts with `facts.` scope" do
+    path = "/test/%{facts.test_fact}/file"
+    facts = {"test_fact" => "replaced"}
+    expected_result = "/test/replaced/file"
+
+    assert_equal expected_result, HieraData::Interpolation.interpolate_facts(path: path, facts: facts)
+  end
+
   test "::interpolate_facts replaces nested facts" do
     path = "/test/%{nested.fact}/file"
     facts = {"nested" => {"fact" => "deep"}}


### PR DESCRIPTION
Variables of the form `${::var}` and `${facts.var}` should now result in the same interpolation.