### PR TITLE
Allow disabling of authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,18 +9,23 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    if User.none?
-      session[:user_id] = nil
-    end
+    @current_user ||=
+      if Rails.configuration.hdm.authentication_disabled
+        DummyUser.new
+      else
+        if User.none?
+          session[:user_id] = nil
+        end
 
-    if session[:user_id]
-      Current.user ||= User.find(session[:user_id])
-    end
+        if session[:user_id]
+          Current.user ||= User.find(session[:user_id])
+        end
+      end
   end
 
   def authentication_required
     unless current_user
-      if User.none?
+      if User.none? && !(Rails.configuration.hdm.authentication_disabled)
         redirect_to new_user_path, notice: 'Please create an admin user first.'
       else
         redirect_to login_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   def authentication_required
     unless current_user
-      if User.none? && !(Rails.configuration.hdm.authentication_disabled)
+      if User.none? && !Rails.configuration.hdm.authentication_disabled
         redirect_to new_user_path, notice: 'Please create an admin user first.'
       else
         redirect_to login_path

--- a/app/models/dummy_user.rb
+++ b/app/models/dummy_user.rb
@@ -1,8 +1,6 @@
 class DummyUser
   def initialize
-    unless Rails.configuration.hdm.authentication_disabled
-      raise "cannot be used unless authentication is disabled"
-    end
+    raise "cannot be used unless authentication is disabled" unless Rails.configuration.hdm.authentication_disabled
   end
 
   def id

--- a/app/models/dummy_user.rb
+++ b/app/models/dummy_user.rb
@@ -1,0 +1,23 @@
+class DummyUser
+  def initialize
+    unless Rails.configuration.hdm.authentication_disabled
+      raise "cannot be used unless authentication is disabled"
+    end
+  end
+
+  def id
+    nil
+  end
+
+  def email
+    "anonymous"
+  end
+
+  def admin?
+    false
+  end
+
+  def user?
+    true
+  end
+end

--- a/app/views/shared/_top_navigation.html.erb
+++ b/app/views/shared/_top_navigation.html.erb
@@ -17,9 +17,11 @@
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
               <% if current_user %>
-                <%= link_to edit_user_path(current_user), class: 'dropdown-item' do %>
-                  <%= icon "person" %>
-                  Edit Profile
+                <% if can? :update, current_user %>
+                  <%= link_to edit_user_path(current_user), class: 'dropdown-item' do %>
+                    <%= icon "person" %>
+                    Edit Profile
+                  <% end %>
                 <% end %>
                 <%= link_to logout_path, class: 'dropdown-item' do %>
                   <%= icon "box-arrow-right" %>

--- a/test/integration/required_authentication_test.rb
+++ b/test/integration/required_authentication_test.rb
@@ -1,52 +1,85 @@
 require "test_helper"
 
 class RequiredAuthenticationTest < ActionDispatch::IntegrationTest
+  class AuthenticationEnabledTest < ActionDispatch::IntegrationTest
+    test "authentication requirements for environments" do
+      authentication_required_for :get, environments_path
+    end
 
-  test "authentication requirements for environments" do
-    authentication_required_for :get, environments_path
+    test "authentication requiremens for nodes" do
+      authentication_required_for :get, environment_nodes_path("development")
+    end
+
+    test "authentication requirements for keys" do
+      authentication_required_for :get,
+        environment_node_keys_path("development", "testhost")
+      authentication_required_for :get,
+        environment_node_key_path("development", "testhost", "hdm::integer")
+      authentication_required_for :patch,
+        environment_node_key_path("development", "testhost", "hdm::integer")
+      authentication_required_for :delete,
+        environment_node_key_path("development", "testhost", "hdm::integer")
+    end
+
+    test "authentication requirements for decrypted values" do
+      authentication_required_for :post,
+        environment_node_decrypted_values_path("development", "testhost")
+    end
+
+    test "authentication requirements for encrypted values" do
+      authentication_required_for :post,
+        environment_node_encrypted_values_path("development", "testhost")
+    end
+
+    test "authentication requirements for users" do
+      user = FactoryBot.create(:user, admin: true)
+
+      authentication_required_for :get, users_path
+      authentication_required_for :get, user_path(user)
+      authentication_required_for :get, new_user_path
+      authentication_required_for :post, users_path
+      authentication_required_for :get, edit_user_path(user)
+      authentication_required_for :patch, user_path(user)
+      authentication_required_for :delete, user_path(user)
+    end
+
+    private
+
+    def authentication_required_for(method, path)
+      send(method, path)
+      assert_redirected_to login_path
+    end
   end
 
-  test "authentication requiremens for nodes" do
-    authentication_required_for :get, environment_nodes_path("development")
-  end
+  class AuthenticationDisabledTest < ActionDispatch::IntegrationTest
+    setup do
+      Rails.configuration.hdm["authentication_disabled"] = true
+    end
 
-  test "authentication requirements for keys" do
-    authentication_required_for :get,
-      environment_node_keys_path("development", "testhost")
-    authentication_required_for :get,
-      environment_node_key_path("development", "testhost", "hdm::integer")
-    authentication_required_for :patch,
-      environment_node_key_path("development", "testhost", "hdm::integer")
-    authentication_required_for :delete,
-      environment_node_key_path("development", "testhost", "hdm::integer")
-  end
+    teardown do
+      Rails.configuration.hdm["authentication_disabled"] = nil
+    end
 
-  test "authentication requirements for decrypted values" do
-    authentication_required_for :post,
-      environment_node_decrypted_values_path("development", "testhost")
-  end
+    test "authentication requirements for environments" do
+      no_authentication_required_for :get, environments_path
+    end
 
-  test "authentication requirements for encrypted values" do
-    authentication_required_for :post,
-      environment_node_encrypted_values_path("development", "testhost")
-  end
+    test "authentication requiremens for nodes" do
+      no_authentication_required_for :get, environment_nodes_path("development")
+    end
 
-  test "authentication requirements for users" do
-    user = FactoryBot.create(:user, admin: true)
+    test "authentication requirements for keys" do
+      no_authentication_required_for :get,
+        environment_node_keys_path("development", "testhost")
+      no_authentication_required_for :get,
+        environment_node_key_path("development", "testhost", "hdm::integer")
+    end
 
-    authentication_required_for :get, users_path
-    authentication_required_for :get, user_path(user)
-    authentication_required_for :get, new_user_path
-    authentication_required_for :post, users_path
-    authentication_required_for :get, edit_user_path(user)
-    authentication_required_for :patch, user_path(user)
-    authentication_required_for :delete, user_path(user)
-  end
+    private
 
-  private
-
-  def authentication_required_for(method, path)
-    send(method, path)
-    assert_redirected_to login_path
+    def no_authentication_required_for(method, path)
+      send(method, path)
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
See #54 

I took the commit referenced there, rebased against `main` and added a few tests.

This now allows to disable authentication by setting `authentication_disabled: true` in `config/hdm.yml`.

What is missing in my opinion is an example of this in either `config/hdm.yml.template` or the documentation. But I was not sure where a suitable place would be. Also I am not 100% sure how this will be used or is supposed to be used (like is this more a `development` thing or will it be used in `production` primarily?). So you might want to add this.

(Please note: We talked about adding `fixes #[issue number]` to PRs, so issues can be closed automatically. I did not do this here on purpose because I am not certain all requirements of #54 are met when this is merged.)