### PR TITLE
Upgrade data attributes to turbo syntax #109

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -41,7 +41,7 @@
               <% end %>
             <% end %>
             <% if can? :delete, user %>
-              <%= link_to user, method: :delete, data: { confirm: user_deletion_confirmation(user) }, class:"btn btn-sm btn-danger min-width-btn" do %>
+              <%= link_to user, data: {turbo_method: :delete, turbo_confirm: user_deletion_confirmation(user) }, class:"btn btn-sm btn-danger min-width-btn" do %>
                 <%= icon "trash" %>
                 Delete
               <% end %>


### PR DESCRIPTION
As opposed to the old jquery-rails style.

It looks like I did not include `jquery-rails` into the javascript bundle after upgrading to Rails 7. This resulted in the user deletion button not working.

The missing functionality has since been integrated into the `turbo` library, so `jquery-rails` is not strictly needed anymore. I upgraded the syntax to work with turbo.

Fixes #109.

(We should probably also remove the `jquery-rails` gem from `Gemfile`, but I would like to wait until after #106 has been merged, to avoid merge conflicts.)