### PR TITLE
Add task to reset admin password #101

### DIFF
--- a/lib/tasks/hdm.rake
+++ b/lib/tasks/hdm.rake
@@ -10,4 +10,15 @@ namespace :hdm do
       puts "Done."
     end
   end
+
+  desc "Reset admin password"
+  task :reset_admin, [:email] => :environment do |task, args|
+    raise "Email argument missing" unless args.email
+    admin = User.admins.where(email: args.email).first
+    raise "Could not find admin #{args.email}" if admin.nil?
+    new_password = SecureRandom.base36
+    admin.update!(password: new_password)
+    puts "The new password is:"
+    puts new_password
+  end
 end


### PR DESCRIPTION
This adds a task to reset the password of an admin user to a random string.

It can be executed via

```sh
bin/rails hdm:reset_admin[email]
```
where `email` is the email address of the admin user to reset.

I did not add any documentation because I was not sure where to put it. Also, since docker is the official installation method, I guess it will need to be executed slightly differently.

Fixes #101
