### PR TITLE
simplify tagging

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -33,21 +33,11 @@ jobs:
           version = "${{ github.ref }}".replace("refs/tags/v", "")
           image = "ghcr.io/${{ github.repository }}"
           tags = set()
-          # full version
-          if not version == 'refs/heads/main':
-              tags.add(f"{image}:{version}")
           if version == 'refs/heads/main':
               tags.add(f"{image}:development")
-          if not parse(version).is_prerelease:
-              # only final and post-releases should get the tags
-              # used for automatic use of latest *stable* version
-              # major_version
-              if not version == 'refs/heads/main':
-                  major_version = re.search(r'(\d+?)\.', version).group(1)
-                  tags.add(f"{image}:{major_version}")
-                  # major_version.minor_version
-                  major_and_minor_version = re.search(r'(\d+?\.\d+?)\.', version).group(1)
-                  tags.add(f"{image}:{major_and_minor_version}")
+          else:
+              tags.add(f"{image}:{version}")
+              if not parse(version).is_prerelease:
                   tags.add(f"{image}:latest")
           tags = ",".join(sorted(list(tags)))
           print(f"::set-output name=tags::{tags}")


### PR DESCRIPTION
- restructure if-contruct
- dont tag major and minor
- only tag full version
- dont try to parse refs/heads/main for pre-releases