### PR TITLE
Add license information to footer #70

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,13 @@
           <%= image_tag "betadots.png", alt: "betadots logo", width: "32", height: "32" %>
           betadots GmbH
         </a>
+        -
+        Licensed under GNU Affero General Public License v3.0
+        -
+        <a href="https://github.com/betadots/hdm">
+          <%= icon("github") %>
+          Source code
+        </a>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
I made the requested changes to the footer. It is a bit simplistic, but might do:

![image](https://user-images.githubusercontent.com/68106/214802844-755f6cec-4ae6-42cb-ba4a-0bbeed8e8ab9.png)
