### PR TITLE
Improve error handling of ldap login #117

### DIFF
--- a/app/controllers/ldap_sessions_controller.rb
+++ b/app/controllers/ldap_sessions_controller.rb
@@ -21,7 +21,7 @@ class LdapSessionsController < ApplicationController
       end
     else
       flash.now[:alert] = "Email or password is invalid"
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/models/ldap.rb
+++ b/app/models/ldap.rb
@@ -14,7 +14,7 @@ class Ldap
   end
 
   def authenticate(email, password)
-    ldap.bind_as(filter: "(mail=#{email})", password: password)
+    ldap.bind_as(filter: "(mail=#{email})", password: password) if email.present? && password.present?
   end
 
   private

--- a/test/controllers/ldap_sessions_controller_test.rb
+++ b/test/controllers/ldap_sessions_controller_test.rb
@@ -23,7 +23,7 @@ class LdapSessionsControllerTest < ActionDispatch::IntegrationTest
       post ldap_session_path,
            params: { email: "noboby@example.com", password: "secret" }
 
-      assert_response :success
+      assert_response :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
When entering wrong credentials during ldap login, the error message was not displayed, due to the way turbo handles responses to `POST` requests.

Giving to credentials at all resulted in an exception.

This fixes both problems.