### PR TITLE
Fix loading of stimulus controllers.

### DIFF
--- a/app/javascript/controllers/append_controller.js
+++ b/app/javascript/controllers/append_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus"
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["container", "template"];

--- a/app/javascript/controllers/remove_controller.js
+++ b/app/javascript/controllers/remove_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus"
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   remove(event) {


### PR DESCRIPTION
I caught a small error in the JS setup. This was a remnant of an earlier version where this worked. I guess it broke either when we switched to importmaps or when we updated some dependency.

However, this PR fixes that.