### PR TITLE
Deep merge hiera defaults #108

### DIFF
--- a/app/models/hiera_data/config.rb
+++ b/app/models/hiera_data/config.rb
@@ -22,7 +22,7 @@ class HieraData
                else
                  {}
                end
-      defaults.merge(config)
+      defaults.deep_merge(config)
     rescue => error
       raise Hdm::Error, error
     end

--- a/app/models/hiera_data/hierarchy.rb
+++ b/app/models/hiera_data/hierarchy.rb
@@ -1,6 +1,6 @@
 class HieraData
   class Hierarchy
-    LOOKUP_FUNCTIONS = %w(data_hash lookup_key data_dig hiera3_backend).freeze
+    LOOKUP_FUNCTIONS = %w(lookup_key data_hash data_dig hiera3_backend).freeze
     attr_reader :raw_hash
 
     def initialize(raw_hash:, base_path:)

--- a/test/fixtures/files/puppet/environments/no_datadir/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/no_datadir/hiera.yaml
@@ -1,0 +1,5 @@
+---
+version: 5
+
+defaults:
+  lookup_key: eyaml_lookup_key

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -10,6 +10,7 @@ class EnvironmentTest < ActiveSupport::TestCase
       minimal
       multiple_hierarchies
       no_config
+      no_datadir
       test
       v3
     )

--- a/test/models/hiera_data/config_test.rb
+++ b/test/models/hiera_data/config_test.rb
@@ -34,6 +34,18 @@ class HieraData::ConfigTest < ActiveSupport::TestCase
     end
   end
 
+  class HieraData::ConfigNoDatadirInYamlFile < ActiveSupport::TestCase
+    test "uses default datadir from puppet" do
+      config = HieraData::Config.new(base_path)
+      assert_not_nil config.content["defaults"]
+      assert_equal Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH["defaults"]["datadir"], config.content["defaults"]["datadir"]
+    end
+
+    def base_path
+      Pathname.new(Rails.configuration.hdm["config_dir"]).join("environments", "no_datadir")
+    end
+  end
+
   class HieraData::ConfigWithSomeHierarchiesTest < ActiveSupport::TestCase
     test "when only defaults, return the yaml paths" do
       config = HieraData::Config.new(base_path)


### PR DESCRIPTION
Before this, hiera defaults were only used when defaults were missing altogether from `hiera.yaml`. This changes that behavior by doing a proper deep merge.

Fixes #108 