### PR TITLE
Disable environments not available in fs #147

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,13 +1,20 @@
 class Environment < HieraModel
   attribute :name, :string
   attribute :in_use, :boolean, default: false
+  attribute :available, :boolean, default: false
 
   def self.all
     environments_in_use = PuppetDbClient.environments
     available_environments = HieraData.environments
-    unused_environments = available_environments - environments_in_use
-    environments_in_use.sort.map { |e| new(name: e, in_use: true) } +
-      unused_environments.sort.map { |e| new(name: e) }
+    all_environments = {}
+    environments_in_use.sort.each do |e|
+      all_environments[e] = { name: e, in_use: true }
+    end
+    available_environments.sort.each do |e|
+      all_environments[e] ||= { name: e }
+      all_environments[e][:available] = true
+    end
+    all_environments.map { |_, attributes| new(**attributes) }
   end
 
   def self.find(name)
@@ -20,6 +27,10 @@ class Environment < HieraModel
 
   def in_use?
     in_use
+  end
+
+  def available?
+    available
   end
 
   def ==(other)

--- a/app/views/environments/_select_environment.html.erb
+++ b/app/views/environments/_select_environment.html.erb
@@ -4,7 +4,7 @@
     <select name="environment" data-controller="select-navigation" data-action="change->select-navigation#navigate" data-slim-select-target="dropdown">
       <option value="" <%= "selected" if @environment.nil? %> data-url="<%= environments_path %>"></option>
       <% @environments.each do |environment| %>
-        <option data-url="<%= environment_nodes_path(environment) %>" <%= "selected" if environment == @environment %>>
+        <option data-url="<%= environment_nodes_path(environment) %>" <%= "selected" if environment == @environment %> <%= "disabled" unless environment.available? %>>
           <%= environment.name %><%= " (unused)" unless environment.in_use? %>
         </option>
       <% end %>

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class EnvironmentTest < ActiveSupport::TestCase
-  test "list the environments" do
+  test "::all lists the environments" do
     expected_environments = %w(
       development
       eyaml
@@ -16,6 +16,14 @@ class EnvironmentTest < ActiveSupport::TestCase
       old_unused
     )
     assert_equal expected_environments, Environment.all.map(&:name)
+  end
+
+  test "::all correctly marks unavailable environments" do
+    PuppetDbClient.stub :environments, ["unavailable"] do
+      environments = Environment.all
+      unavailable_environment = environments.find { |e| e.name == "unavailable" }
+      assert_not unavailable_environment.available?
+    end
   end
 
   test "::find correctly sets the `in_use` flag" do


### PR DESCRIPTION
PuppetDB might report environments that are not actually available in the file system (e.g. due to short-lived feature branches). This change displays the environments in the dropdown, but disables them, so they cannot be selected.

Fixes #147