### PR TITLE
Interpolate facts in datadir setting #157

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,7 @@ Naming/PredicateName:
     - "have_"
 Rails/I18nLocaleTexts:
   Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - "test/**/*.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,6 @@ Layout/CaseIndentation:
 Layout/EmptyLineAfterGuardClause:
   Exclude:
     - 'app/models/hiera_data/config.rb'
-    - 'app/models/hiera_data/hierarchy.rb'
     - 'app/models/hiera_data/yaml_file.rb'
 
 # Offense count: 2
@@ -48,13 +47,6 @@ Layout/EmptyLineAfterGuardClause:
 Layout/EmptyLineBetweenDefs:
   Exclude:
     - 'test/models/hiera_data/config_test.rb'
-    - 'test/models/hiera_data/hierarchy_test.rb'
-
-# Offense count: 1
-# This cop supports safe auto-correction (--auto-correct).
-Layout/EmptyLines:
-  Exclude:
-    - 'test/models/hiera_data/hierarchy_test.rb'
 
 # Offense count: 2
 # This cop supports safe auto-correction (--auto-correct).
@@ -146,7 +138,6 @@ Layout/MultilineArrayBraceLayout:
 Layout/MultilineMethodCallIndentation:
   Exclude:
     - 'app/models/hiera_data/data_file.rb'
-    - 'app/models/hiera_data/hierarchy.rb'
     - 'app/models/key.rb'
 
 # Offense count: 13
@@ -175,7 +166,6 @@ Layout/SpaceInsideHashLiteralBraces:
   Exclude:
     - 'config/routes.rb'
     - 'test/models/hiera_data/data_file_test.rb'
-    - 'test/models/hiera_data/hierarchy_test.rb'
     - 'test/models/hiera_data/interpolation_test.rb'
     - 'test/models/hiera_data/yaml_file_test.rb'
     - 'test/models/hiera_data_test.rb'

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -37,7 +37,7 @@ class DataFile < HieraModel
   end
 
   def keys
-    @keys ||= hiera_data.keys_in_file(hierarchy.name, path).map do |key_name|
+    @keys ||= hiera_data.keys_in_file(hierarchy.name, path, facts: node&.facts).map do |key_name|
       Key.new(environment:, name: key_name)
     end
   end

--- a/app/models/hiera_data.rb
+++ b/app/models/hiera_data.rb
@@ -27,7 +27,7 @@ class HieraData
     keys = []
     config.hierarchies.each do |hierarchy|
       hierarchy.resolved_paths(facts:).each do |path|
-        file = DataFile.new(path: hierarchy.datadir.join(path), facts:)
+        file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
         keys.concat(file.keys)
       end
     end
@@ -41,7 +41,7 @@ class HieraData
 
   def file_attributes(hierarchy_name, path, facts: nil)
     hierarchy = find_hierarchy(hierarchy_name)
-    file = DataFile.new(path: hierarchy.datadir.join(path), facts:)
+    file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
     {
       exist: file.exist?,
       writable: file.writable?,
@@ -49,14 +49,14 @@ class HieraData
     }
   end
 
-  def keys_in_file(hierarchy_name, path)
+  def keys_in_file(hierarchy_name, path, facts: nil)
     hierarchy = find_hierarchy(hierarchy_name)
-    DataFile.new(path: hierarchy.datadir.join(path)).keys
+    DataFile.new(path: hierarchy.datadir(facts:).join(path)).keys
   end
 
   def value_in_file(hierarchy_name, path, key, facts: {})
     hierarchy = find_hierarchy(hierarchy_name)
-    file = DataFile.new(path: hierarchy.datadir.join(path), facts:)
+    file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
     file.content_for_key(key)
   end
 
@@ -65,7 +65,7 @@ class HieraData
     files = facts ? hierarchy.resolved_paths(facts:) : hierarchy.candidate_files
     search_results = {}
     files.each do |path|
-      file = DataFile.new(path: hierarchy.datadir.join(path), facts:)
+      file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
       search_results[path] = {
         file_present: file.exist?,
         file_writable: file.writable?,
@@ -95,13 +95,13 @@ class HieraData
 
   def write_key(hierarchy_name, path, key, value, facts: {})
     hierarchy = find_hierarchy(hierarchy_name)
-    read_file = DataFile.new(path: hierarchy.datadir.join(path), facts:)
+    read_file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
     read_file.write_key(key, value)
   end
 
   def remove_key(hierarchy_name, path, key, facts: {})
     hierarchy = find_hierarchy(hierarchy_name)
-    read_file = DataFile.new(path: hierarchy.datadir.join(path), facts:)
+    read_file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
     read_file.remove_key(key)
   end
 
@@ -128,7 +128,7 @@ class HieraData
     result = {}
     config.hierarchies.each do |hierarchy|
       hierarchy.resolved_paths(facts:).each do |path|
-        file = DataFile.new(path: hierarchy.datadir.join(path))
+        file = DataFile.new(path: hierarchy.datadir(facts:).join(path))
         result = (file["lookup_options"] || {}).merge(result)
       end
     end

--- a/app/models/hiera_data/hierarchy.rb
+++ b/app/models/hiera_data/hierarchy.rb
@@ -30,9 +30,12 @@ class HieraData
         end
     end
 
-    def datadir
+    def datadir(facts: nil)
       return @datadir if @datadir
-      path = Pathname.new(raw_hash["datadir"])
+
+      raw_datadir = raw_hash["datadir"]
+      raw_datadir = Interpolation.interpolate_facts(path: raw_datadir, facts:) if facts
+      path = Pathname.new(raw_datadir)
       if path.absolute?
         path
       else
@@ -71,7 +74,7 @@ class HieraData
         resolved_path = Interpolation.interpolate_facts(path:, facts:)
         if uses_globs?
           resolved_path = Interpolation
-            .interpolate_globs(path: resolved_path, datadir:)
+                          .interpolate_globs(path: resolved_path, datadir:)
         end
         resolved_path
       end

--- a/test/fixtures/files/puppet/environments/dynamic_datadir/data1/common.yaml
+++ b/test/fixtures/files/puppet/environments/dynamic_datadir/data1/common.yaml
@@ -1,0 +1,4 @@
+---
+hdm::float: 0.1
+hdm::integer: 1
+foobar::enable_firstrun: false

--- a/test/fixtures/files/puppet/environments/dynamic_datadir/data2/common.yaml
+++ b/test/fixtures/files/puppet/environments/dynamic_datadir/data2/common.yaml
@@ -1,0 +1,4 @@
+---
+hdm::float: 0.3
+hdm::integer: 4
+foobar::enable_firstrun: true

--- a/test/fixtures/files/puppet/environments/dynamic_datadir/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/dynamic_datadir/hiera.yaml
@@ -1,0 +1,10 @@
+version: 5
+defaults:
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "dynamic hierarchy"
+    datadir: "%{facts.custom.datadir}"
+    paths:
+      - "nodes/%{::facts.fqdn}.yaml"
+      - "common.yaml"

--- a/test/fixtures/files/puppet/nodes/caegfj58.betadots.training_facts.yaml
+++ b/test/fixtures/files/puppet/nodes/caegfj58.betadots.training_facts.yaml
@@ -1,0 +1,7 @@
+---
+fqdn: 'caegfj58.betadots.training'
+role: 'hdm_test'
+environment: 'dynamic_datadir'
+zone: 'internal'
+custom:
+  datadir: 'data1'

--- a/test/fixtures/files/puppet/nodes/kq8l8lbw.betadots.training_facts.yaml
+++ b/test/fixtures/files/puppet/nodes/kq8l8lbw.betadots.training_facts.yaml
@@ -1,0 +1,7 @@
+---
+fqdn: 'kq8l8lbw.betadots.training'
+role: 'hdm_test'
+environment: 'dynamic_datadir'
+zone: 'internal'
+custom:
+  datadir: 'data2'

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -4,6 +4,7 @@ class EnvironmentTest < ActiveSupport::TestCase
   test "::all lists the environments" do
     expected_environments = %w(
       development
+      dynamic_datadir
       eyaml
       globs
       hdm

--- a/test/models/hiera_data/hierarchy_test.rb
+++ b/test/models/hiera_data/hierarchy_test.rb
@@ -3,21 +3,21 @@ require 'test_helper'
 class HieraData::HierarchyTest < ActiveSupport::TestCase
   test "#uses_globs? returns true if `glob` key present" do
     glob = "/*/singular/glob"
-    raw_hash = {"name" => "Singular path", "glob" => glob}
+    raw_hash = { "name" => "Singular path", "glob" => glob }
     hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path: ".")
     assert hierarchy.uses_globs?
   end
 
   test "#uses_globs? returns true if `globs` key present" do
     globs = ["/*/array/globs", "/test/**/globs"]
-    raw_hash = {"name" => "Singular path", "globs" => globs}
+    raw_hash = { "name" => "Singular path", "globs" => globs }
     hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path: ".")
     assert hierarchy.uses_globs?
   end
 
   test "#paths supports the singular `path` setting" do
     path = "/test/singular/path"
-    raw_hash = {"name" => "Singular path", "path" => path}
+    raw_hash = { "name" => "Singular path", "path" => path }
     hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path: ".")
     assert_equal [path], hierarchy.paths
   end
@@ -41,14 +41,14 @@ class HieraData::HierarchyTest < ActiveSupport::TestCase
 
   test "#paths supports the singular `glob` setting" do
     glob = "/*/singular/glob"
-    raw_hash = {"name" => "Singular path", "glob" => glob}
+    raw_hash = { "name" => "Singular path", "glob" => glob }
     hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path: ".")
     assert_equal [glob], hierarchy.paths
   end
 
   test "#paths supports the `globs` array setting" do
     globs = ["/*/array/globs", "/test/**/globs"]
-    raw_hash = {"name" => "Singular path", "globs" => globs}
+    raw_hash = { "name" => "Singular path", "globs" => globs }
     hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path: ".")
     assert_equal globs, hierarchy.paths
   end
@@ -74,9 +74,9 @@ class HieraData::HierarchyTest < ActiveSupport::TestCase
   test "#resolved_paths resolves globs" do
     base_path = Rails.root.join("test/fixtures/files/puppet/environments/globs")
     globs = ["common/*.yaml"]
-    raw_hash = {"name" => "Common", "datadir" => "data", "globs" => globs}
+    raw_hash = { "name" => "Common", "datadir" => "data", "globs" => globs }
     hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path:)
-    facts = {"fqdn" => "testhost"}
+    facts = { "fqdn" => "testhost" }
     expected_resolved_paths = [
       "common/foobar.yaml",
       "common/hdm.yaml"
@@ -104,6 +104,18 @@ class HieraData::HierarchyTest < ActiveSupport::TestCase
       "common.yaml"
     ]
     assert_equal expected_candidate_files, hierarchy.candidate_files
+  end
+
+  test "#datadir uses facts to resolve datadir" do
+    raw_hash = {
+      "name" => "dynamic datadir",
+      "datadir" => "%{facts.datadir}"
+    }
+    facts = { "datadir" => "data1" }
+    base_path = Rails.root.join("test/fixtures/files/puppet/environments/dynamic_datadir")
+    hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path:)
+
+    assert_equal base_path.join("data1"), hierarchy.datadir(facts:)
   end
 
   def raw_hash
@@ -146,7 +158,6 @@ class HieraData::HierarchyTest < ActiveSupport::TestCase
       }
     end
   end
-
 
   class HieraData::HierarchyForEyamlDataTest < ActiveSupport::TestCase
     setup do


### PR DESCRIPTION
Fixes #157 

This was not too big a change after all. As it turned out, there was only one method that accessed the datadir where no facts were available. But even there, a node should already be present, so it was easy to add.

Please give this a try.