### PR TITLE
Fix for emtpy `defaults` section #204

### DIFF
--- a/app/models/hiera_data/config.rb
+++ b/app/models/hiera_data/config.rb
@@ -22,6 +22,7 @@ class HieraData
                else
                  {}
                end
+      config['defaults'] ||= {}
       defaults.deep_merge(config)
     rescue => error
       raise Hdm::Error, error

--- a/test/fixtures/files/puppet/environments/empty_defaults/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/empty_defaults/hiera.yaml
@@ -1,0 +1,7 @@
+---
+version: 5
+defaults:
+hierarchy:
+  - name: "common settings"
+    paths:
+      - "common.yaml"

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -5,6 +5,7 @@ class EnvironmentTest < ActiveSupport::TestCase
     expected_environments = %w(
       development
       dynamic_datadir
+      empty_defaults
       eyaml
       globs
       hdm

--- a/test/models/hiera_data/config_test.rb
+++ b/test/models/hiera_data/config_test.rb
@@ -56,4 +56,16 @@ class HieraData::ConfigTest < ActiveSupport::TestCase
       Pathname.new(Rails.configuration.hdm["config_dir"]).join("environments", "multiple_hierarchies")
     end
   end
+
+  class HieraData::ConfigWithEmptyDefaultsTest < ActiveSupport::TestCase
+    test "empty defaults get replaced" do
+      config = HieraData::Config.new(base_path)
+      assert_not_nil config.content["defaults"]
+      assert_equal Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH["defaults"], config.content["defaults"]
+    end
+
+    def base_path
+      Pathname.new(Rails.configuration.hdm["config_dir"]).join("environments", "empty_defaults")
+    end
+  end
 end


### PR DESCRIPTION
Merging hiera's defaults did not work when `defaults` was given in `hiera.yaml`, but empty (== `nil`).

Fixes #204.