### PR TITLE
Correct the CMD syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY config/hdm.yml.template $APP_HOME/config/hdm.yml
 
 RUN bundle check || (bundle config set --local without 'development test' && bundle install)
 
-CMD ["/hdm/bin/entry.sh ${HDM_PORT} ${HDM_HOST}"]
+CMD ["/hdm/bin/entry.sh", "${HDM_PORT}", "${HDM_HOST}"]


### PR DESCRIPTION
when we introduced the possibility to swithc ports, we added params to the CMD.
But params must be provided as single array elements