### PR TITLE
fix setting hostname and port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY config/hdm.yml.template $APP_HOME/config/hdm.yml
 
 RUN bundle check || (bundle config set --local without 'development test' && bundle install)
 
-CMD ["/hdm/bin/entry.sh", "${HDM_PORT}", "${HDM_HOST}"]
+CMD ["sh", "-c", "/hdm/bin/entry.sh ${HDM_PORT} ${HDM_HOST}"]

--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -11,4 +11,4 @@ bundle exec rails db:seed
 ./bin/fake_puppet_db &
 fi
 
-bundle exec rails server -b "${HDM_HOST}" -p "${HDM_PORT}"
+bundle exec rails server -b $HDM_HOST -p $HDM_PORT

--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -10,5 +10,5 @@ if [[ "${DEVELOP}" -eq 1 ]]; then
 bundle exec rails db:seed
 ./bin/fake_puppet_db &
 fi
-
+# shellcheck disable=SC2086
 bundle exec rails server -b $HDM_HOST -p $HDM_PORT


### PR DESCRIPTION
when using env vars in CMD, one must use `sh -c` to allow variable evaluation