### PR TITLE
Improve first access flow #234

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,8 +25,8 @@ class ApplicationController < ActionController::Base
 
   def authentication_required
     unless current_user
-      if User.none? && !Rails.configuration.hdm.authentication_disabled
-        redirect_to new_user_path, notice: 'Please create an admin user first.'
+      if admin_user_missing?
+        redirect_to initial_setup_path, notice: 'Please create an admin user first.'
       else
         redirect_to login_path
       end
@@ -47,5 +47,9 @@ class ApplicationController < ActionController::Base
 
   def access_denied
     render file: Rails.public_path.join('403.html'), status: :forbidden, layout: false
+  end
+
+  def admin_user_missing?
+    User.none? && !Rails.configuration.hdm.authentication_disabled
   end
 end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -9,6 +9,5 @@ class PageController < ApplicationController
     end
   end
 
-  def initial_setup
-  end
+  def initial_setup; end
 end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -4,8 +4,11 @@ class PageController < ApplicationController
   add_breadcrumb "Home", :root_path
 
   def index
-    if User.none?
-      redirect_to new_user_path, notice: 'Please create an admin user first.'
+    if admin_user_missing?
+      redirect_to initial_setup_path
     end
+  end
+
+  def initial_setup
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,4 +41,8 @@ module ApplicationHelper
   def role_badge_color(role)
     ROLE_BADGE_COLORS[role]
   end
+
+  def external_auth_configured?
+    Ldap.configured? || Saml.configured?
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -32,7 +32,7 @@ class Ability
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 
-    if User.none?
+    if user.blank? && User.none?
       can :create, User
     else
       return if user.blank?

--- a/app/views/page/index.html.erb
+++ b/app/views/page/index.html.erb
@@ -1,25 +1,43 @@
-<%= image_tag "logo_full.png", alt: "Hiera Data Manager logo", width: "50%" %>
-<p>HDM is a webfrontend for visualizing and managing Hiera data.</p>
-<% unless current_user %>
-  <%= render template: "sessions/new" %>
-<% else %>
-  <% if User.count == 1 && current_user.admin? %>
-    <h2>First Step: Create a User</h2>
-    <p>Your account (<%= current_user.email %>) has admin priviliges which allow to manage users but which do not
-    allow to manage the puppet configuration.</p>
-    <p><strong>=> <%= link_to "Create a new user", new_user_path %></strong> who is not an admin to
-    get access to the puppet configuration.</p>
-  <% end %>
-  <% if can? :index, Environment %>
-    <%= link_to environments_path, class: "btn btn-primary" do %>
-      <%= icon "list" %>
-      Show Environments
+<div class="row">
+  <div class="col-md-6">
+    <% unless current_user %>
+      <%= render template: "sessions/new" %>
+    <% else %>
+      <% if User.count == 1 && current_user.admin? %>
+        <% if external_auth_configured? %>
+          <h2>Welcome</h2>
+          <p>You can now create additional admin users or setup groups for finer grained access control.</p>
+          <p>Or sign out to now to login as a regular user authenticated via your external authentication source (LDAP/AD/SSO).</p>
+          <%= link_to logout_path, class: "btn btn-primary" do %>
+            <%= icon "box-arrow-right" %>
+            Sign out now
+          <% end %>
+          <p></p>
+        <% else %>
+          <h2>First Step: Create a User</h2>
+          <p>Your account (<%= current_user.email %>) has admin priviliges which allow to manage users but which do not
+          allow to manage the puppet configuration.</p>
+          <p><strong>=> <%= link_to "Create a new user", new_user_path %></strong> who is not an admin to
+          get access to the puppet configuration.</p>
+        <% end %>
+      <% end %>
+      <% if can? :index, Environment %>
+        <%= link_to environments_path, class: "btn btn-primary" do %>
+          <%= icon "list" %>
+          Show Environments
+        <% end %>
+      <% end %>
+      <% if can? :create, User %>
+        <%= link_to users_path, class: "btn btn-primary" do %>
+          <%= icon "people" %>
+          Manage Users
+        <% end %>
+      <% end %>
     <% end %>
-  <% end %>
-  <% if can? :create, User %>
-    <%= link_to users_path, class: "btn btn-primary" do %>
-      <%= icon "people" %>
-      Manage Users
-    <% end %>
-  <% end %>
-<% end %>
+  </div>
+  <div class="col-md-6 text-end">
+    <%= image_tag "logo_full.png", alt: "Hiera Data Manager logo", width: "80%" %>
+    <p>HDM is a webfrontend for visualizing and managing Hiera data.</p>
+  </div>
+</div>
+

--- a/app/views/page/initial_setup.html.erb
+++ b/app/views/page/initial_setup.html.erb
@@ -1,0 +1,40 @@
+<div class="row">
+  <div class="col-md-6">
+    <h2>Welcome to HDM</h2>
+
+    <p>
+      To get started, you need to create an admin user. Admin user credentials
+      are kept in a local database. Admin users can create new regular users
+      and manage access rules. Admin users cannot access Hiera data.
+    </p>
+
+    <p>
+      <%= link_to "Create admin user", new_user_path, class: "btn btn-primary" %>
+    </p>
+
+    <% if external_auth_configured? %>
+      <p>
+        You have already configured external authentication resources, so once
+        an admin user is created setup is complete.
+      </p>
+    <% else %>
+      <p>
+        Regular users, stored in the local database, can be managed by an
+        admin user. Alternatively you can configure LDAP/AD or SAML (SSO) as
+        a source of authentication for regular users.
+      </p>
+
+      <p>
+        LDAP/AD or SAML can be configured in <code>config/hdm.yml</code>.
+        Have a look at
+        <%= link_to "examples here", "https://github.com/betadots/hdm/blob/92219b98f48e29d9c2c9b64d8b8f0996e58d88c5/config/hdm.yml.template#L55-L80" %>.
+        Remember to restart HDM when making changes to <code>config/hdm.yml</code>.
+      </p>
+    <% end %>
+  </div>
+  <div class="col-md-6 text-end">
+    <%= image_tag "logo_full.png", alt: "Hiera Data Manager logo", width: "80%" %>
+    <p>HDM is a webfrontend for visualizing and managing Hiera data.</p>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,11 +48,11 @@ Rails.application.routes.draw do
   resource :ldap_session, only: [:new, :create]
   resource :saml_session, only: [:new, :create]
 
-  get 'page/index'
+  get '/signup', to: 'users#new', as: 'signup'
+  get '/login', to: 'sessions#new', as: 'login'
+  get '/logout', to: 'sessions#destroy', as: 'logout'
 
-  get 'signup', to: 'users#new', as: 'signup'
-  get 'login', to: 'sessions#new', as: 'login'
-  get 'logout', to: 'sessions#destroy', as: 'logout'
+  get '/initial_setup', to: 'page#initial_setup', as: :initial_setup
 
   root to: 'page#index'
 end

--- a/test/controllers/page_controller_test.rb
+++ b/test/controllers/page_controller_test.rb
@@ -1,15 +1,22 @@
 require 'test_helper'
 
 class PageControllerTest < ActionDispatch::IntegrationTest
-  test "system without an existing user shouldn't get index but new user form" do
+  test "system without an existing user shouldn't get index but initial setup page" do
     User.destroy_all
-    get page_index_url
-    assert_redirected_to new_user_path
+    get root_url
+    assert_redirected_to initial_setup_path
   end
 
   test "system with existing user should get index" do
     FactoryBot.create(:user)
-    get page_index_url
+    get root_url
     assert_response :success
+  end
+
+  test "system with authentication disabled should get index" do
+    Rails.configuration.hdm["authentication_disabled"] = true
+    get root_url
+    assert_response :success
+    Rails.configuration.hdm["authentication_disabled"] = nil
   end
 end


### PR DESCRIPTION
Adds a welcome page upon first access that explains that an admin user is needed and displays information about external authentication sources if applicable.

It no longer prompts to create a new regular user if external authentication is already configured.

If authentication is disabled none of this is displayed (fixes #54).

Please note that this does not exactly match the ideas mentioned in #234. Please have a look and see if you like it anyways.

Fixes #234