### PR TITLE
Remove unused dependency `redis`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem 'stimulus-rails'
 gem 'bootstrap', '~> 5.3.0'
 gem 'bootstrap-icons-helper'
 
-# Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 5.0'
 # Use Active Model has_secure_password
 gem 'bcrypt', '~> 3.1.20'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,10 +354,6 @@ GEM
     rchardet (1.8.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
-    redis-client (0.18.0)
-      connection_pool
     regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
@@ -500,7 +496,6 @@ DEPENDENCIES
   puppet
   puppetdb-ruby
   rails (~> 7.1.3)
-  redis (~> 5.0)
   rspec-openapi
   rubocop (~> 1.60.2)
   rubocop-capybara (~> 2.20.0)


### PR DESCRIPTION
I looked at #297 and wondered why we have this dependency at all.

We do not currently use redis and since it would complicate deployment, I do not think we will officially support it any time soon.

So I think it is fine to remove this for now.