### PR TITLE
Interpolate variables in datadir used for globs #329

### DIFF
--- a/app/models/hiera_data/hierarchy.rb
+++ b/app/models/hiera_data/hierarchy.rb
@@ -81,7 +81,7 @@ class HieraData
         resolved_path = Interpolation.interpolate_facts(path:, facts:)
         if uses_globs?
           resolved_path = Interpolation
-                          .interpolate_globs(path: resolved_path, datadir:)
+                          .interpolate_globs(path: resolved_path, datadir: datadir(facts:))
         end
         resolved_path
       end

--- a/test/models/hiera_data/hierarchy_test.rb
+++ b/test/models/hiera_data/hierarchy_test.rb
@@ -85,6 +85,18 @@ class HieraData
       assert_equal expected_resolved_paths, hierarchy.resolved_paths(facts:)
     end
 
+    test "#resolved_paths resolves globs when given a dynamic datadir" do
+      base_path = Rails.root.join("test/fixtures/files/puppet/environments/dynamic_datadir")
+      globs = ["c*.yaml"]
+      raw_hash = { "name" => "Common", "datadir" => "%{facts.custom.datadir}", "globs" => globs }
+      hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path:)
+      facts = { "custom" => { "datadir" => "data1" }  }
+      expected_resolved_paths = [
+        "common.yaml"
+      ]
+      assert_equal expected_resolved_paths, hierarchy.resolved_paths(facts:)
+    end
+
     test "#name returns the existing name" do
       hierarchy = HieraData::Hierarchy.new(raw_hash:, base_path: ".")
       assert_equal "Yaml hierarchy", hierarchy.name


### PR DESCRIPTION
Found it!

When interpolating globs we need the current datadir. But at that point, interpolation of variables in the datadir itself was not yet done. So anytime a glob was used, it was taking any variables in the datadir's path literally.

The commit here fixes this.

Fixes #329