### PR TITLE
Take global layer into account

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,8 +12,6 @@
 # SupportedStyles: with_first_argument, with_fixed_indentation
 Layout/ArgumentAlignment:
   Exclude:
-    - 'app/controllers/keys_controller.rb'
-    - 'app/models/hiera_data/data_file.rb'
     - 'test/controllers/keys_controller_test.rb'
     - 'test/integration/required_authentication_test.rb'
 
@@ -49,21 +47,6 @@ Layout/EmptyLinesAroundClassBody:
   Exclude:
     - 'test/controllers/sessions_controller_test.rb'
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Exclude:
-    - 'test/models/hiera_data_test.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: special_inside_parentheses, consistent, align_brackets
-Layout/FirstArrayElementIndentation:
-  Exclude:
-    - 'test/models/hiera_data_test.rb'
-
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Layout/HeredocIndentation:
@@ -87,15 +70,6 @@ Layout/IndentationWidth:
     - 'app/controllers/users_controller.rb'
     - 'test/models/hiera_data/yaml_file_test.rb'
 
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented, indented_relative_to_receiver
-Layout/MultilineMethodCallIndentation:
-  Exclude:
-    - 'app/models/hiera_data/data_file.rb'
-    - 'app/models/key.rb'
-
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator, EnforcedStyleForRationalLiterals.
@@ -106,7 +80,6 @@ Layout/SpaceAroundOperators:
     - 'app/models/hiera_data/yaml_file.rb'
     - 'test/models/hiera_data/data_file_test.rb'
     - 'test/models/hiera_data/yaml_file_test.rb'
-    - 'test/models/hiera_data_test.rb'
 
 # Offense count: 43
 # This cop supports safe autocorrection (--autocorrect).
@@ -118,7 +91,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'test/models/hiera_data/data_file_test.rb'
     - 'test/models/hiera_data/interpolation_test.rb'
     - 'test/models/hiera_data/yaml_file_test.rb'
-    - 'test/models/hiera_data_test.rb'
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -128,17 +100,10 @@ Layout/TrailingWhitespace:
     - 'config/initializers/friendly_id.rb'
 
 # Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Lint/AmbiguousRegexpLiteral:
-  Exclude:
-    - 'test/models/hiera_data_test.rb'
-
-# Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:
   Exclude:
-    - 'app/models/hiera_data/data_file.rb'
     - 'app/models/hiera_data/git_repo.rb'
 
 # Offense count: 1
@@ -193,7 +158,6 @@ Rails/FilePath:
   Exclude:
     - 'test/models/hiera_data/data_file_test.rb'
     - 'test/models/hiera_data/yaml_file_test.rb'
-    - 'test/models/hiera_data_test.rb'
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
@@ -203,7 +167,6 @@ Rails/FilePath:
 Rails/RefuteMethods:
   Exclude:
     - 'test/models/hiera_data/yaml_file_test.rb'
-    - 'test/models/hierarchy_test.rb'
     - 'test/models/user_test.rb'
 
 # Offense count: 5
@@ -279,7 +242,6 @@ Style/GuardClause:
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/page_controller.rb'
     - 'app/controllers/sessions_controller.rb'
-    - 'app/models/hiera_data/data_file.rb'
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -314,7 +276,6 @@ Style/PercentLiteralDelimiters:
   Exclude:
     - 'config/initializers/friendly_id.rb'
     - 'test/models/environment_test.rb'
-    - 'test/models/key_test.rb'
 
 # Offense count: 3
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ production:
 
   config_dir: /etc/puppetlabs/code  # puppet code directory
 
+  global_hiera_yaml: /etc/puppetlabs/puppet/hiera.yaml
+
   ldap:                             # LDAP User auth
     host: 'localhost'
     port: 389

--- a/app/controllers/api/v1/keys_controller.rb
+++ b/app/controllers/api/v1/keys_controller.rb
@@ -9,13 +9,13 @@ module Api
 
         respond_to do |format|
           format.json do
-            render json: @keys.to_json(except: :environment)
+            render json: @keys.to_json
           end
         end
       end
 
       def show
-        @key = Key.new(environment: @environment, name: params[:id])
+        @key = Key.new(name: params[:id])
         authorize! :show, @key
 
         respond_to do |format|
@@ -28,7 +28,7 @@ module Api
       private
 
       def values_per_hierarchy_and_file
-        @environment.hierarchies.map do |hierarchy|
+        @environment.environment_layer.hierarchies.map do |hierarchy|
           files = hierarchy.files_for(node: @node).map do |file|
             { path: file.path, value: file.value_for(key: @key).value }
           end

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -6,9 +6,9 @@ class FilesController < ApplicationController
   add_breadcrumb "Environments", :environments_path
 
   def index
-    @files_and_values_by_hierarchy =
+    @files_and_values =
       if can? :show, @key
-        DataFile.search(@environment, @key)
+        @key.search(environment: @environment)
       else
         {}
       end
@@ -20,6 +20,6 @@ class FilesController < ApplicationController
   private
 
   def load_key
-    @key = Key.new(environment: @environment, name: params[:key_id].squish)
+    @key = Key.new(name: params[:key_id].squish)
   end
 end

--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -17,29 +17,11 @@ class KeysController < ApplicationController
   def show
     @keys = Key.all_for(@node, environment: @environment)
     @keys.select! { |k| current_user.may_access?(k) }
-    @key = Key.new(environment: @environment, name: params[:id])
+    @key = Key.new(name: params[:id], hiera_data: @environment.hiera_data)
     authorize! :show, @key
 
     add_breadcrumb @environment, environment_nodes_path(@environment)
     add_breadcrumb @node, environment_node_keys_path(@environment, @node)
     add_breadcrumb params[:id], environment_node_key_path(@environment, @node, params[:id])
-  end
-
-  def update
-    @key = Key.new(@node, params[:id])
-    authorize! :update, @key
-    @key.save_value(params[:hierarchy], params[:path], params[:value])
-
-    redirect_to environment_node_key_path(@environment, @node, @key),
-      notice: "Value was saved successfully"
-  end
-
-  def destroy
-    @key = Key.new(@node, params[:id])
-    authorize! :destroy, @key
-    @key.remove_value(params[:hierarchy], params[:path])
-
-    redirect_to environment_node_key_path(@environment, @node, @key),
-      notice: "Value was removed successfully"
   end
 end

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -17,7 +17,7 @@ class LookupsController < ApplicationController
   def load_keys
     @keys = Key.all_for(@node, environment: @environment)
     @keys.select! { |k| current_user.may_access?(k) }
-    @key = Key.new(environment: @environment, name: params[:key_id])
+    @key = Key.new(name: params[:key_id], hiera_data: @environment.hiera_data)
     authorize! :show, @key
   end
 

--- a/app/controllers/values_controller.rb
+++ b/app/controllers/values_controller.rb
@@ -4,7 +4,7 @@ class ValuesController < ApplicationController
   def update
     authorize! :update, Key
 
-    @value.update(params[:value], node: @node)
+    @value.update(params[:value])
 
     redirect_to environment_node_key_path(@environment, @node, @key),
                 notice: "Value was saved successfully"
@@ -13,7 +13,7 @@ class ValuesController < ApplicationController
   def destroy
     authorize! :destroy, Key
 
-    @value.destroy(node: @node)
+    @value.destroy
 
     redirect_to environment_node_key_path(@environment, @node, @key),
                 status: :see_other,
@@ -25,9 +25,10 @@ class ValuesController < ApplicationController
   def instantiate_models
     @environment = Environment.find(params[:environment_id])
     @node = Node.new(hostname: params[:node_id], environment: @environment)
-    @hierarchy = Hierarchy.find(@environment, params[:hierarchy_id])
-    @data_file = DataFile.new(hierarchy: @hierarchy, path: params[:data_file_id])
-    @key = Key.new(environment: @environment, name: params[:key_id])
+    @layer = @environment.find_layer(name: params[:layer_id])
+    @hierarchy = Hierarchy.find(layer: @layer, name: params[:hierarchy_id])
+    @data_file = @hierarchy.file(path: params[:data_file_id], node: @node)
+    @key = Key.new(name: params[:key_id])
     @value = @data_file.value_for(key: @key)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
 
   def format_path(file, key)
     tag_name, classes =
-      if file.has_key?(key) # rubocop:disable Style/PreferredHashMethods
+      if file.has_key?(key:) # rubocop:disable Style/PreferredHashMethods
         [:b, "text-primary"]
       elsif file.exist?
         [:span, "text-dark"]

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -1,53 +1,34 @@
 class DataFile < HieraModel
   attribute :hierarchy
-  attribute :node
   attribute :path, :string
   attribute :exist, :boolean, default: false
   attribute :writable, :boolean, default: false
   attribute :replaced_from_git, :boolean, default: false
+  attribute :hiera_file
 
   delegate :environment, to: :hierarchy
 
-  def self.search(environment, key)
-    hierarchies = {}
-    result = {}
-    HieraData.new(environment.name).files_including(key.name).each do |file|
-      hierarchies[file[:hierarchy_name]] ||= Hierarchy.new(
-        environment:,
-        name: file[:hierarchy_name],
-        backend: file[:hierarchy_backend]
-      )
-      data_file = new(
-        hierarchy: hierarchies[file[:hierarchy_name]],
-        path: file[:path]
-      )
-      value = Value.new(data_file:, key:, value: file[:value])
-      result[hierarchies[file[:hierarchy_name]]] ||= {}
-      result[hierarchies[file[:hierarchy_name]]][data_file] = value
-    end
-    result
-  end
-
   def initialize(attributes = {})
     super(attributes)
-    file_attributes = hiera_data.file_attributes(hierarchy.name, path, facts: node&.facts)
-    self.exist = file_attributes[:exist]
-    self.writable = file_attributes[:writable]
-    self.replaced_from_git = file_attributes[:replaced_from_git]
+    return unless hiera_file
+
+    self.exist = hiera_file.exist?
+    self.writable = hiera_file.writable?
+    self.replaced_from_git = hiera_file.replaced_from_git?
   end
 
   def keys
-    @keys ||= hiera_data.keys_in_file(hierarchy.name, path, facts: node&.facts).map do |key_name|
-      Key.new(environment:, name: key_name)
+    @keys ||= hiera_file.keys.map do |key_name|
+      Key.new(name: key_name)
     end
   end
 
-  def has_key?(key)
+  def has_key?(key:)
     keys.include?(key)
   end
 
   def value_for(key:)
-    raw_value = (hiera_data.value_in_file(hierarchy.name, path, key.name, facts: node&.facts) if has_key?(key)) # rubocop:disable Style/PreferredHashMethods
+    raw_value = (hiera_file.content_for_key(key.name) if has_key?(key:)) # rubocop:disable Style/PreferredHashMethods
     Value.new(data_file: self, key:, value: raw_value)
   end
 
@@ -71,28 +52,26 @@ class DataFile < HieraModel
     [node&.name, path].join("-").parameterize
   end
 
-  def has_differing_value_in_original_environment?(key)
+  def has_differing_value_in_original_environment?(node:, key:)
     return false unless environment && node.environment
     return false if environment == node.environment
 
-    candidate_files = node.environment.hierarchies.map do |h|
-      self.class.new(hierarchy: h, path:, node:)
+    candidate_files = node.environment.environment_layer.hierarchies.map do |h|
+      h.file(path:, node:)
     end
     other_file = candidate_files.find(&:exist?)
     return false unless other_file
 
-    other_key = Key.new(environment: node.environment, name: key.name)
-    return false if value_for(key:).value == other_file.value_for(key: other_key).value
+    return false if value_for(key:).value == other_file.value_for(key:).value
 
     true
   end
 
-  def value_from_original_environment(key:)
-    candidate_files = (node&.environment&.hierarchies || []).map do |h|
-      self.class.new(hierarchy: h, path:, node:)
+  def value_from_original_environment(node:, key:)
+    candidate_files = (node&.environment&.environment_layer&.hierarchies || []).map do |h|
+      h.file(path:, node:)
     end
     other_file = candidate_files.find(&:exist?)
-    other_key = Key.new(environment: node.environment, name: key.name)
-    other_file.value_for(key: other_key)
+    other_file.value_for(key:)
   end
 end

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -5,7 +5,9 @@ class Environment < HieraModel
 
   def self.all
     environments_in_use = PuppetDbClient.environments
-    available_environments = HieraData.environments
+    available_environments = HieraData.environments(
+      config_dir: Rails.configuration.hdm.config_dir
+    )
     all_environments = {}
     environments_in_use.sort.each do |e|
       all_environments[e] = { name: e, in_use: true }
@@ -21,8 +23,16 @@ class Environment < HieraModel
     all.find { |e| e.name == name }
   end
 
-  def hierarchies
-    Hierarchy.all(self)
+  def layers
+    Layer.all(environment: self)
+  end
+
+  def find_layer(name:)
+    layers.find { |l| l.name == name }
+  end
+
+  def environment_layer
+    @environment_layer ||= find_layer(name: "environment")
   end
 
   def in_use?
@@ -43,5 +53,9 @@ class Environment < HieraModel
 
   def to_s
     name
+  end
+
+  def hiera_data
+    @hiera_data ||= HieraData.new(environment: name)
   end
 end

--- a/app/models/hiera_data.rb
+++ b/app/models/hiera_data.rb
@@ -1,6 +1,4 @@
 class HieraData
-  class EnvironmentNotFound < StandardError; end
-
   attr_reader :environment, :layers
 
   def self.environments(config_dir:)

--- a/app/models/hiera_data.rb
+++ b/app/models/hiera_data.rb
@@ -1,126 +1,35 @@
-# rubocop:disable Metrics/ClassLength
 class HieraData
   class EnvironmentNotFound < StandardError; end
 
-  attr_reader :environment
+  attr_reader :environment, :layers
 
-  delegate :hierarchies, to: :config
-
-  def self.environments
+  def self.environments(config_dir:)
     Pathname.new(config_dir)
             .join("environments")
             .glob("*/")
             .map { |p| p.basename.to_s }
   end
 
-  def self.config_dir
-    @config_dir ||= Rails.configuration.hdm.config_dir
-  end
-
-  def initialize(environment)
+  def initialize(environment:)
     @environment = environment
-
-    raise EnvironmentNotFound, "Environment '#{environment}' does not exist" unless self.class.environments.include?(environment)
+    @layers = HieraData::Layer.for(environment:)
   end
 
-  def all_keys(facts)
-    keys = []
-    config.hierarchies.each do |hierarchy|
-      hierarchy.resolved_paths(facts:).each do |path|
-        file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
-        keys.concat(file.keys)
-      end
-    end
-    keys.sort.uniq
+  def find_layer(layer_name:)
+    @layers.find { |l| l.name == layer_name }
   end
 
-  def files_for(hierarchy_name, facts: {})
-    hierarchy = find_hierarchy(hierarchy_name)
-    hierarchy.resolved_paths(facts:)
+  def find_hierarchy(layer_name:, hierarchy_name:)
+    find_layer(layer_name:).find_hierarchy(hierarchy_name:)
   end
 
-  def file_attributes(hierarchy_name, path, facts: nil)
-    hierarchy = find_hierarchy(hierarchy_name)
-    file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
-    {
-      exist: file.exist?,
-      writable: file.writable?,
-      replaced_from_git: file.replaced_from_git?
-    }
+  def all_keys(facts:)
+    @layers.flat_map { |l| l.all_keys(facts:) }
+           .sort.uniq
   end
 
-  def keys_in_file(hierarchy_name, path, facts: nil)
-    hierarchy = find_hierarchy(hierarchy_name)
-    DataFile.new(path: hierarchy.datadir(facts:).join(path)).keys
-  end
-
-  def value_in_file(hierarchy_name, path, key, facts: {})
-    hierarchy = find_hierarchy(hierarchy_name)
-    file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
-    file.content_for_key(key)
-  end
-
-  def search_key(hierarchy_name, key, facts: nil)
-    hierarchy = find_hierarchy(hierarchy_name)
-    files = facts ? hierarchy.resolved_paths(facts:) : hierarchy.candidate_files
-    search_results = {}
-    files.each do |path|
-      file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
-      search_results[path] = {
-        file_present: file.exist?,
-        file_writable: file.writable?,
-        key_present: file.keys.include?(key), # rubocop:disable Performance/InefficientHashSearch
-        replaced_from_git: file.replaced_from_git?,
-        value: file.content_for_key(key)
-      }
-    end
-    search_results
-  end
-
-  def files_including(key)
-    hierarchies.flat_map do |hierarchy|
-      search_results = search_key(hierarchy.name, key)
-      search_results.map do |path, search_result|
-        next unless search_result[:key_present]
-
-        {
-          path:,
-          hierarchy_name: hierarchy.name,
-          hierarchy_backend: hierarchy.backend,
-          value: search_result[:value]
-        }
-      end
-    end.compact
-  end
-
-  def write_key(hierarchy_name, path, key, value, facts: {})
-    hierarchy = find_hierarchy(hierarchy_name)
-    read_file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
-    read_file.write_key(key, value)
-  end
-
-  def remove_key(hierarchy_name, path, key, facts: {})
-    hierarchy = find_hierarchy(hierarchy_name)
-    read_file = DataFile.new(path: hierarchy.datadir(facts:).join(path), facts:)
-    read_file.remove_key(key)
-  end
-
-  def decrypt_value(hierarchy_name, value)
-    hierarchy = find_hierarchy(hierarchy_name)
-    public_key = hierarchy.public_key
-    private_key = hierarchy.private_key
-    EYamlFile.decrypt_value(value, public_key:, private_key:)
-  end
-
-  def encrypt_value(hierarchy_name, value)
-    hierarchy = find_hierarchy(hierarchy_name)
-    public_key = hierarchy.public_key
-    private_key = hierarchy.private_key
-    EYamlFile.encrypt_value(value, public_key:, private_key:)
-  end
-
-  def lookup_options_for(key, facts: {}, decrypt: false)
-    candidates = lookup_for(facts, decrypt:)
+  def lookup_options_for(key:, facts: {}, decrypt: false)
+    candidates = lookup_for(facts:, decrypt:)
                  .lookup("lookup_options", merge_strategy: :hash)
     merge = extract_merge_value(key, candidates)
     case merge
@@ -133,34 +42,17 @@ class HieraData
     end
   end
 
-  def lookup(key, facts: {}, decrypt: false)
-    merge_strategy = lookup_options_for(key, facts:, decrypt:).to_sym
-    lookup_for(facts).lookup(key, merge_strategy:)
+  def lookup(key:, facts: {}, decrypt: false)
+    merge_strategy = lookup_options_for(key:, facts:, decrypt:).to_sym
+    lookup_for(facts:).lookup(key, merge_strategy:)
   end
 
   private
 
-  def config
-    @config ||= Config.new(Pathname.new(self.class.config_dir)
-      .join("environments", environment))
-  end
-
-  def find_hierarchy(name)
-    config.hierarchies.find { |h| h.name == name }
-  end
-
-  def lookup_for(facts, decrypt: false)
+  def lookup_for(facts:, decrypt: false)
     @cached_lookups ||= {}
     @cached_lookups[facts] ||= begin
-      hashes = config.hierarchies.flat_map do |hierarchy|
-        hierarchy.resolved_paths(facts:).map do |path|
-          DataFile.new(
-            path: hierarchy.datadir(facts:).join(path),
-            type: hierarchy.backend,
-            options: hierarchy.file_options.merge({ decrypt: })
-          ).content
-        end
-      end
+      hashes = @layers.flat_map { |l| l.file_contents(facts:, decrypt:) }
       Lookup.new(hashes.compact)
     end
   end
@@ -173,4 +65,3 @@ class HieraData
     result&.dig("merge")
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/hiera_data/config.rb
+++ b/app/models/hiera_data/config.rb
@@ -2,8 +2,9 @@ class HieraData
   class Config
     attr_reader :content, :hierarchies
 
-    def initialize(base_path)
-      @base_path = base_path
+    def initialize(hiera_yaml)
+      @hiera_yaml = hiera_yaml
+      @base_path = File.dirname(hiera_yaml)
       @content = load_content
       initialize_hierarchies
     end
@@ -11,10 +12,9 @@ class HieraData
     private
 
     def load_content
-      full_path = @base_path.join(Rails.configuration.hdm.hiera_config_file || "hiera.yaml")
       defaults = Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH
-      config = if File.exist?(full_path)
-                 parsed_file = YAML.load_file(full_path)
+      config = if File.exist?(@hiera_yaml)
+                 parsed_file = YAML.load_file(@hiera_yaml)
                  unless parsed_file["version"] == 5
                    raise Hdm::Error, "hdm needs your hiera.yaml configuration to be in the version 5 format. Please convert your config file(s) before using hdm."
                  end

--- a/app/models/hiera_data/data_file.rb
+++ b/app/models/hiera_data/data_file.rb
@@ -3,8 +3,8 @@ class HieraData
     attr_reader :path, :file
 
     delegate :content, :exist?, :writable?, :keys,
-      :content_for_key, :[],
-      to: :file
+             :content_for_key, :[],
+             to: :file
 
     def initialize(path:, facts: {}, options: {}, type: :yaml)
       @path = path
@@ -33,25 +33,25 @@ class HieraData
     private
 
     def setup_git_location
-      if git_data = matching_git_location
-        @git_repo = GitRepo.new(git_data[:git_url])
-        interpolated_path_in_repo = Interpolation
-          .interpolate_facts(path: git_data[:path_in_repo], facts: @facts)
-          .delete_prefix("/")
-        path_in_repo = @git_repo.local_path.join(interpolated_path_in_repo).to_s
-        path_in_repo << "/" unless path_in_repo.last == "/"
-        @path = Pathname.new(
-          @path.to_s.sub(git_data[:replaces_datadir_interpolated],
-                         path_in_repo.to_s)
-        )
-        @replaced_from_git = true
-      end
+      return unless (git_data = matching_git_location)
+
+      @git_repo = GitRepo.new(git_data[:git_url])
+      interpolated_path_in_repo = Interpolation
+                                  .interpolate_facts(path: git_data[:path_in_repo], facts: @facts)
+                                  .delete_prefix("/")
+      path_in_repo = @git_repo.local_path.join(interpolated_path_in_repo).to_s
+      path_in_repo << "/" unless path_in_repo.last == "/"
+      @path = Pathname.new(
+        @path.to_s.sub(git_data[:replaces_datadir_interpolated],
+                       path_in_repo.to_s)
+      )
+      @replaced_from_git = true
     end
 
     def matching_git_location
       Rails.configuration.hdm.git_data&.find do |git_data|
         replaces_datadir = Interpolation
-          .interpolate_facts(path: git_data[:datadir], facts: @facts)
+                           .interpolate_facts(path: git_data[:datadir], facts: @facts)
         replaces_datadir << "/" unless replaces_datadir.last == "/"
         git_data[:replaces_datadir_interpolated] = replaces_datadir
         @path.to_s.start_with?(replaces_datadir)

--- a/app/models/hiera_data/interpolation.rb
+++ b/app/models/hiera_data/interpolation.rb
@@ -4,7 +4,7 @@ class HieraData
 
     module_function
 
-    def interpolate_globs(path:, datadir:)
+    def interpolate_globs(path:, datadir: nil)
       Dir.glob(path, base: datadir).sort
     end
 

--- a/app/models/hiera_data/layer.rb
+++ b/app/models/hiera_data/layer.rb
@@ -1,0 +1,76 @@
+class HieraData
+  module Layer
+    class Base
+      delegate :hierarchies, to: :config
+
+      def present?
+        File.exist?(hiera_yaml)
+      end
+
+      def all_keys(facts:)
+        hierarchies.flat_map { |h| h.all_keys(facts:) }.sort.uniq
+      end
+
+      def file_contents(facts:, decrypt: false)
+        hierarchies.flat_map { |h| h.file_contents(facts:, decrypt:) }
+      end
+
+      private
+
+      def config
+        @config ||= Config.new(hiera_yaml)
+      end
+
+      def find_hierarchy(hierarchy_name:)
+        config.hierarchies.find { |h| h.name == hierarchy_name }
+      end
+
+      def hiera_yaml
+        filename = Rails.configuration.hdm.hiera_config_file || "hiera.yaml"
+        base_path.join(filename)
+      end
+    end
+
+    class Global < Base
+      def base_path
+        Pathname.new("/etc/puppetlabs/puppet")
+      end
+
+      def name
+        "global"
+      end
+
+      def to_param
+        name
+      end
+    end
+
+    class Environment < Base
+      def initialize(environment:)
+        super()
+        @environment = environment
+      end
+
+      def base_path
+        Pathname.new(Rails.configuration.hdm.config_dir)
+                .join("environments", @environment)
+      end
+
+      def name
+        "environment"
+      end
+
+      def to_param
+        name
+      end
+    end
+
+    class Module < Base
+      # TODO
+    end
+
+    def self.for(environment:)
+      [Global.new, Environment.new(environment:)].select(&:present?)
+    end
+  end
+end

--- a/app/models/hiera_data/layer.rb
+++ b/app/models/hiera_data/layer.rb
@@ -33,7 +33,7 @@ class HieraData
 
     class Global < Base
       def base_path
-        Pathname.new("/etc/puppetlabs/puppet")
+        hiera_yaml.dirname
       end
 
       def name
@@ -42,6 +42,14 @@ class HieraData
 
       def to_param
         name
+      end
+
+      private
+
+      def hiera_yaml
+        Pathname.new(
+          Rails.configuration.hdm.global_hiera_yaml || "/etc/puppetlabs/puppet/hiera.yaml"
+        )
       end
     end
 

--- a/app/models/hiera_model.rb
+++ b/app/models/hiera_model.rb
@@ -3,9 +3,5 @@ class HieraModel
   include ActiveModel::Attributes
   include ActiveModel::Serializers::JSON
 
-  private
-
-  def hiera_data
-    @hiera_data ||= HieraData.new(environment.name) if respond_to?(:environment)
-  end
+  attribute :hiera_data
 end

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -1,0 +1,25 @@
+class Layer < HieraModel
+  attribute :name
+  attribute :environment
+  attribute :hiera_layer
+
+  def self.all(environment: nil)
+    hiera_data = environment ? environment.hiera_data : HieraData.new
+    hiera_data.layers.map do |layer|
+      new(
+        name: layer.name,
+        hiera_data:,
+        hiera_layer: layer,
+        environment: layer.name == "environment" ? environment : nil
+      )
+    end
+  end
+
+  def hierarchies
+    Hierarchy.all(layer: self)
+  end
+
+  def to_param
+    name
+  end
+end

--- a/app/models/value.rb
+++ b/app/models/value.rb
@@ -3,21 +3,18 @@ class Value < HieraModel
   attribute :key
   attribute :value, :string
 
-  delegate :hierarchy, to: :data_file
-  delegate :environment, to: :hierarchy
+  delegate :hiera_file, to: :data_file
 
   def encrypted?
     HieraData::EYamlFile.encrypted?(value)
   end
 
-  def update(new_value, node: nil)
+  def update(new_value)
     parsed_value = YAML.safe_load(new_value)
-    facts = node ? node.facts : {}
-    hiera_data.write_key(data_file.hierarchy.name, data_file.path, key.name, parsed_value, facts:)
+    hiera_file.write_key(key.name, parsed_value)
   end
 
-  def destroy(node: nil)
-    facts = node ? node.facts : {}
-    hiera_data.remove_key(data_file.hierarchy.name, data_file.path, key.name, facts:)
+  def destroy
+    hiera_file.remove_key(data_file.path, key.name)
   end
 end

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -11,11 +11,11 @@
   <div class="col-12">
     <h2>Search Results</h2>
     <p class="lead">
-      <% if @files_and_values_by_hierarchy.any? %>
+      <% if @files_and_values.any? %>
         Found key
         <code><%= @key.name %></code>
         in
-        <b><%= t(".file", count: @files_and_values_by_hierarchy.values.map { |f| f.size }.sum) %></b>.
+        <b><%= t(".file", count: @files_and_values.values.flat_map { |f| f.values }.flat_map { |f| f.values.size }.sum) %></b>.
       <% else %>
         Could not find key
         <code><%= @key.name %></code>
@@ -29,45 +29,50 @@
   <div class="col-12">
     <% hierarchy_index = 0 %>
     <% file_index = 0 %>
-    <% @files_and_values_by_hierarchy.each do |hierarchy, files_and_values| %>
-      <% hierarchy_index += 1 %>
-      <div id="accordion-<%= hierarchy_index %>" class="accordion mb-2">
-        <div class="accordion-item">
-          <div class="accordion-header" id="hierarchy-<%= hierarchy_index %>">
-            <button class="accordion-button text-start" type="button" data-bs-toggle="collapse" data-bs-target="#hierarchy-collapse-<%= hierarchy_index %>" aria-expanded="false" aria-controls="hierarchy-collapse-<%= hierarchy_index %>">
-              <b><%= hierarchy.name %></b>
-              <span class="badge bg-primary text-light ms-2"><%= hierarchy.backend %></span>
-              <em class="ms-2">- <%= t(".file", count: files_and_values.size) %></em>
-            </button>
-          </div>
-        </div>
-        <div class="accordion-collapse collapse" id="hierarchy-collapse-<%= hierarchy_index %>" data-bs-parent="accordion-<%= hierarchy_index %>" aria-labelledby="hierarchy-<%= hierarchy_index %>">
-          <%# <div class="accordion-body"> %>
-            <% files_and_values.each do |file, value| %>
-              <% file_index += 1 %>
-              <div id="file-accordion-<%= file_index %>" class="accordion accordion-flush">
-                <div class="accordion-item">
-                  <h2 class="accordion-header" id="path-<%= file_index %>">
-                    <button class="accordion-button bg-light text-start d-flex justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= file_index %>" aria-expanded="false" aria-controls="collapse-<%= file_index %>">
-                      <span>
-                        <b><%= file.path %></b>
-                        <% if value&.encrypted? %>
-                          <span class="text-danger">
-                            <%= icon("lock-fill") %>
-                          </span>
-                        <% end %>
-                      </span>
-                    </button>
-                  </h2>
-                </div>
-                <div id="collapse-<%= file_index %>" class="accordion-collapse collapse" data-bs-parent="file-accordion-<%= file_index %>" aria-labelledby="path-<%= file_index %>">
-                  <div class="accordion-body">
-                    <pre><%= value.value %></pre>
-                  </div>
+    <% @files_and_values.each do |layer, hierarchies| %>
+      <div class="card mb-2">
+        <div class="card-header">Layer: <%= layer.name %></div>
+        <div class="card-body">
+          <% hierarchies.each do |hierarchy, files_and_values| %>
+            <% hierarchy_index += 1 %>
+            <div id="accordion-<%= hierarchy_index %>" class="accordion mb-2">
+              <div class="accordion-item">
+                <div class="accordion-header" id="hierarchy-<%= hierarchy_index %>">
+                  <button class="accordion-button text-start" type="button" data-bs-toggle="collapse" data-bs-target="#hierarchy-collapse-<%= hierarchy_index %>" aria-expanded="false" aria-controls="hierarchy-collapse-<%= hierarchy_index %>">
+                    <b><%= hierarchy.name %></b>
+                    <span class="badge bg-primary text-light ms-2"><%= hierarchy.backend %></span>
+                    <em class="ms-2">- <%= t(".file", count: files_and_values.size) %></em>
+                  </button>
                 </div>
               </div>
-            <% end %>
-          <%# </div> %>
+              <div class="accordion-collapse collapse" id="hierarchy-collapse-<%= hierarchy_index %>" data-bs-parent="accordion-<%= hierarchy_index %>" aria-labelledby="hierarchy-<%= hierarchy_index %>">
+                <% files_and_values.each do |file, value| %>
+                  <% file_index += 1 %>
+                  <div id="file-accordion-<%= file_index %>" class="accordion accordion-flush">
+                    <div class="accordion-item">
+                      <h2 class="accordion-header" id="path-<%= file_index %>">
+                        <button class="accordion-button bg-light text-start d-flex justify-content-between" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= file_index %>" aria-expanded="false" aria-controls="collapse-<%= file_index %>">
+                          <span>
+                            <b><%= file.path %></b>
+                            <% if value&.encrypted? %>
+                              <span class="text-danger">
+                                <%= icon("lock-fill") %>
+                              </span>
+                            <% end %>
+                          </span>
+                        </button>
+                      </h2>
+                    </div>
+                    <div id="collapse-<%= file_index %>" class="accordion-collapse collapse" data-bs-parent="file-accordion-<%= file_index %>" aria-labelledby="path-<%= file_index %>">
+                      <div class="accordion-body">
+                        <pre><%= value.value %></pre>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/keys/_form.html.erb
+++ b/app/views/keys/_form.html.erb
@@ -1,5 +1,5 @@
 <% hierarchy = file.hierarchy %>
-<%= form_with url: (file.writable? ? environment_node_key_hierarchy_data_file_value_path(@environment, @node, @key, hierarchy, file) : nil),
+<%= form_with url: (file.writable? ? environment_node_key_layer_hierarchy_data_file_value_path(@environment, @node, @key, hierarchy.layer, hierarchy, file) : nil),
   method: :patch, local: true,
   data: ({
     controller: "encryption",
@@ -39,8 +39,8 @@
       <% end %>
     <% end %>
     <% if file.writable? %>
-      <% if file.has_key?(@key) %>
-        <%= link_to environment_node_key_hierarchy_data_file_value_path(@environment, @node, @key, hierarchy, file), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-sm btn-danger ms-2" do %>
+      <% if file.has_key?(key: @key) %>
+        <%= link_to environment_node_key_layer_hierarchy_data_file_value_path(@environment, @node, @key, hierarchy.layer, hierarchy, file), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-sm btn-danger ms-2" do %>
           <%= icon "trash" %>
           Delete
         <% end %>

--- a/app/views/keys/_value.html.erb
+++ b/app/views/keys/_value.html.erb
@@ -1,4 +1,4 @@
-<% if file.has_differing_value_in_original_environment?(@key) %>
+<% if file.has_differing_value_in_original_environment?(node: @node, key: @key) %>
   <%= render "shared/tabbed_diff", dom_id: dom_id(file), original_value:file.value_from_original_environment(key: @key).value, current_value: value.value do %>
     <%= render "form", file: file, value: value %>
   <% end %>

--- a/app/views/keys/show.html.erb
+++ b/app/views/keys/show.html.erb
@@ -14,57 +14,64 @@
         </button>
     </div>
     <% index = 0 %>
-    <% @environment.hierarchies.each do |hierarchy| %>
-      <div id="<%= hierarchy.name.parameterize %>" class="accordion">
-        <div class="accordion-item">
-          <h2 class="accordion-header px-3 py-2">
-            <span class="fs-6">
-              <b><%= hierarchy.name %></b>
-              <span class="badge bg-primary text-light"><%= hierarchy.backend %></span>
-            </span>
-          </h2>
-        </div>
-        <% hierarchy.files_for(node: @node).each do |file| %>
-          <% index += 1 %>
-          <% value = file.value_for(key: @key) %>
-          <div class="accordion-item">
-            <h2 class="accordion-header" id="path-<%= index %>">
-              <button class="accordion-button bg-light collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= index %>" aria-expanded="false" aria-controls="collapse-<%= index %>">
-                <span>
-                  <%= format_path(file, @key) %>
-                  <% if value&.encrypted? %>
-                    <span class="ms-2 text-danger">
-                      <%= icon("lock-fill") %>
-                    </span>
-                  <% end %>
-                </span>
-                <span class="text-muted ms-2">
-                  <% if file.replaced_from_git? %>
-                    <span title="This value is taken from a git repository and not from live production data. Changes will be made to the git repository.">
-                      <%= icon("layers") %>
-                    </span>
-                  <% end %>
-                  <% if file.writable? %>
-                    <span title="Value can be edited">
-                      <%= icon("pencil") %>
-                    </span>
-                  <% else %>
-                    <span title="Value is read-only">
-                      <%= icon("eye") %>
-                    </span>
-                  <% end %>
-                </span>
-              </button>
-            </h2>
-
-            <div id="collapse-<%= index %>" class="accordion-collapse collapse" aria-labelledby="path-<%= index %>" data-bs-parent="<%= hierarchy.name.parameterize %>">
-              <div class="accordion-body">
-                <%= render "value", file: file, value: value %>
+    <% @environment.layers.each do |layer| %>
+      <div class="card mb-2">
+        <div class="card-header">Layer: <%= layer.name %></div>
+        <div class="card-body">
+          <% layer.hierarchies.each do |hierarchy| %>
+            <div id="<%= hierarchy.name.parameterize %>" class="accordion">
+              <div class="accordion-item">
+                <h2 class="accordion-header px-3 py-2">
+                  <span class="fs-6">
+                    <b><%= hierarchy.name %></b>
+                    <span class="badge bg-primary text-light"><%= hierarchy.backend %></span>
+                  </span>
+                </h2>
               </div>
-            </div>
+              <% hierarchy.files_for(node: @node).each do |file| %>
+                <% index += 1 %>
+                <% value = file.value_for(key: @key) %>
+                <div class="accordion-item">
+                  <h2 class="accordion-header" id="path-<%= index %>">
+                    <button class="accordion-button bg-light collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<%= index %>" aria-expanded="false" aria-controls="collapse-<%= index %>">
+                      <span>
+                        <%= format_path(file, @key) %>
+                        <% if value&.encrypted? %>
+                          <span class="ms-2 text-danger">
+                            <%= icon("lock-fill") %>
+                          </span>
+                        <% end %>
+                      </span>
+                      <span class="text-muted ms-2">
+                        <% if file.replaced_from_git? %>
+                          <span title="This value is taken from a git repository and not from live production data. Changes will be made to the git repository.">
+                            <%= icon("layers") %>
+                          </span>
+                        <% end %>
+                        <% if file.writable? %>
+                          <span title="Value can be edited">
+                            <%= icon("pencil") %>
+                          </span>
+                        <% else %>
+                          <span title="Value is read-only">
+                            <%= icon("eye") %>
+                          </span>
+                        <% end %>
+                      </span>
+                    </button>
+                  </h2>
+
+                  <div id="collapse-<%= index %>" class="accordion-collapse collapse" aria-labelledby="path-<%= index %>" data-bs-parent="<%= hierarchy.name.parameterize %>">
+                    <div class="accordion-body">
+                      <%= render "value", file: file, value: value %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
           </div>
-        <% end %>
-      </div>
+        </div>
+      </div> 
     <% end %>
   </div>
 </div>

--- a/app/views/keys/show.html.erb
+++ b/app/views/keys/show.html.erb
@@ -68,8 +68,8 @@
                   </div>
                 </div>
               <% end %>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
         </div>
       </div> 
     <% end %>

--- a/config/hdm.yml.template
+++ b/config/hdm.yml.template
@@ -5,6 +5,7 @@ development:
     server: "http://localhost:8083"
   config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
   hiera_config_file: "hiera_hdm.yaml" # if not set, the default value 'hiera.yaml' is used
+  global_hiera_yaml: "/etc/puppetlabs/puppet/hiera.yaml" # Location of the global layer's hiera.yaml
 
 test:
   read_only: false
@@ -16,6 +17,7 @@ test:
   ldap:
     host: localhost
     port: 389
+  #global_hiera_yaml: <%= Rails.root.join('test','fixtures','files','puppet','global','hiera.yml') %>
 
 production:
   read_only: true

--- a/config/hdm.yml.template
+++ b/config/hdm.yml.template
@@ -17,7 +17,7 @@ test:
   ldap:
     host: localhost
     port: 389
-  #global_hiera_yaml: <%= Rails.root.join('test','fixtures','files','puppet','global','hiera.yml') %>
+  #global_hiera_yaml: <%= Rails.root.join('test','fixtures','files','puppet','global','hiera.yaml') %>
 
 production:
   read_only: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,10 +34,12 @@ Rails.application.routes.draw do
           resource :lookup, only: [:show]
         end
       else
-        resources :keys, only: [:index, :show, :update, :destroy] do
-          resources :hierarchies, only: [] do
-            resources :data_files, only: [] do
-              resource :value, only: [:update, :destroy]
+        resources :keys, only: [:index, :show] do
+          resources :layers, only: [] do
+            resources :hierarchies, only: [] do
+              resources :data_files, only: [] do
+                resource :value, only: [:update, :destroy]
+              end
             end
           end
 

--- a/test/fixtures/files/puppet/global/data/common.yaml
+++ b/test/fixtures/files/puppet/global/data/common.yaml
@@ -1,0 +1,3 @@
+---
+hdm::integer: 99
+hdm::float: 2.3

--- a/test/fixtures/files/puppet/global/hiera.yaml
+++ b/test/fixtures/files/puppet/global/hiera.yaml
@@ -1,0 +1,4 @@
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data

--- a/test/integration/required_authentication_test.rb
+++ b/test/integration/required_authentication_test.rb
@@ -24,9 +24,9 @@ class RequiredAuthenticationTest < ActionDispatch::IntegrationTest
 
     test "authentication requirements for values" do
       authentication_required_for :patch,
-        environment_node_key_hierarchy_data_file_value_path("development", "testhost", "hdm::integer", "Eyaml hierarchy", "common.yaml")
+        environment_node_key_layer_hierarchy_data_file_value_path("development", "testhost", "hdm::integer", "environment", "Eyaml hierarchy", "common.yaml")
       authentication_required_for :delete,
-        environment_node_key_hierarchy_data_file_value_path("development", "testhost", "hdm::integer", "Eyaml hierarchy", "common.yaml")
+        environment_node_key_layer_hierarchy_data_file_value_path("development", "testhost", "hdm::integer", "environment", "Eyaml hierarchy", "common.yaml")
     end
 
     test "authentication requirements for decrypted values" do

--- a/test/models/data_file_test.rb
+++ b/test/models/data_file_test.rb
@@ -9,50 +9,56 @@ class DataFileTest < ActiveSupport::TestCase
   end
 
   test "#has_differing_value_in_original_environment? returns false if environments are the same" do
-    hierarchy = Hierarchy.find(@original_environment, "Eyaml hierarchy")
-    data_file = DataFile.new(hierarchy:, node: @node, path: @path)
-    key = Key.new(environment: @original_environment, name: "hdm::integer")
+    layer = @original_environment.environment_layer
+    hierarchy = Hierarchy.find(layer:, name: "Eyaml hierarchy")
+    data_file = hierarchy.file(node: @node, path: @path)
+    key = Key.new(name: "hdm::integer")
 
-    assert_not data_file.has_differing_value_in_original_environment?(key)
+    assert_not data_file.has_differing_value_in_original_environment?(node: @node, key:)
   end
 
   test "#has_differing_value_in_original_environment? returns false if original environment has no file with the same path" do
-    hierarchy = Hierarchy.find(@globs_environment, "Common")
-    data_file = DataFile.new(hierarchy:, node: @node, path: "common/foobar.yaml")
-    key = Key.new(environment: @globs_environment, name: "hdm::integer")
+    layer = @globs_environment.environment_layer
+    hierarchy = Hierarchy.find(layer:, name: "Common")
+    data_file = hierarchy.file(node: @node, path: "common/foobar.yaml")
+    key = Key.new(name: "hdm::integer")
 
-    assert_not data_file.has_differing_value_in_original_environment?(key)
+    assert_not data_file.has_differing_value_in_original_environment?(node: @node, key:)
   end
 
   test "#has_differing_value_in_original_environment? returns false if original environment's value is the same" do
-    hierarchy = Hierarchy.find(@globs_environment, "Eyaml hierarchy")
-    data_file = DataFile.new(hierarchy:, node: @node, path: @path)
-    key = Key.new(environment: @globs_environment, name: "hdm::integer")
+    layer = @globs_environment.environment_layer
+    hierarchy = Hierarchy.find(layer:, name: "Eyaml hierarchy")
+    data_file = hierarchy.file(node: @node, path: @path)
+    key = Key.new(name: "hdm::integer")
 
-    assert_not data_file.has_differing_value_in_original_environment?(key)
+    assert_not data_file.has_differing_value_in_original_environment?(node: @node, key:)
   end
 
   test "#has_differing_value_in_original_environment? returns true if original environment's value is different" do
-    hierarchy = Hierarchy.find(@globs_environment, "Eyaml hierarchy")
-    data_file = DataFile.new(hierarchy:, node: @node, path: @path)
-    key = Key.new(environment: @globs_environment, name: "hdm::float")
+    layer = @globs_environment.environment_layer
+    hierarchy = Hierarchy.find(layer:, name: "Eyaml hierarchy")
+    data_file = hierarchy.file(node: @node, path: @path)
+    key = Key.new(name: "hdm::float")
 
-    assert data_file.has_differing_value_in_original_environment?(key)
+    assert data_file.has_differing_value_in_original_environment?(node: @node, key:)
   end
 
   test "#value_for returns matching value from given environment" do
-    hierarchy = Hierarchy.find(@globs_environment, "Eyaml hierarchy")
-    data_file = DataFile.new(hierarchy:, node: @node, path: @path)
-    key = Key.new(environment: @globs_environment, name: "hdm::float")
+    layer = @globs_environment.environment_layer
+    hierarchy = Hierarchy.find(layer:, name: "Eyaml hierarchy")
+    data_file = hierarchy.file(node: @node, path: @path)
+    key = Key.new(name: "hdm::float")
 
     assert_equal "4.5", data_file.value_for(key:).value
   end
 
   test "#value_from_original_environment returns matching value from the node's original environment" do
-    hierarchy = Hierarchy.find(@globs_environment, "Eyaml hierarchy")
-    data_file = DataFile.new(hierarchy:, node: @node, path: @path)
-    key = Key.new(environment: @globs_environment, name: "hdm::float")
+    layer = @globs_environment.environment_layer
+    hierarchy = Hierarchy.find(layer:, name: "Eyaml hierarchy")
+    data_file = hierarchy.file(node: @node, path: @path)
+    key = Key.new(name: "hdm::float")
 
-    assert_equal "2.3", data_file.value_from_original_environment(key:).value
+    assert_equal "2.3", data_file.value_from_original_environment(node: @node, key:).value
   end
 end

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -61,12 +61,4 @@ class EnvironmentTest < ActiveSupport::TestCase
     development = Environment.new(name: "development")
     assert_equal "development", development.to_s
   end
-
-  test "#hierarchies loads all hierarchies" do
-    environment = Environment.new(name: "development")
-    hierarchies = [Hierarchy.new(environment:, name: "test", backend: :yaml)]
-    Hierarchy.stub(:all, hierarchies) do
-      assert_equal hierarchies, environment.hierarchies
-    end
-  end
 end

--- a/test/models/hiera_data/config_test.rb
+++ b/test/models/hiera_data/config_test.rb
@@ -5,7 +5,7 @@ class HieraData
     class ConfigV3 < ActiveSupport::TestCase
       test "does not support v3 config style" do
         assert_raise Hdm::Error do
-          HieraData::Config.new(base_path)
+          HieraData::Config.new(base_path.join("hiera.yaml"))
         end
       end
 
@@ -16,7 +16,7 @@ class HieraData
 
     class ConfigNoYamlFilePresent < ActiveSupport::TestCase
       test "uses defaults from puppet" do
-        config = HieraData::Config.new(base_path)
+        config = HieraData::Config.new(base_path.join("hiera.yaml"))
         assert_equal 1, config.hierarchies.size
       end
 
@@ -27,7 +27,7 @@ class HieraData
 
     class ConfigMinimalIncompleteYamlFile < ActiveSupport::TestCase
       test "merges with defaults from puppet" do
-        config = HieraData::Config.new(base_path)
+        config = HieraData::Config.new(base_path.join("hiera.yaml"))
         assert_equal 1, config.hierarchies.size
       end
 
@@ -38,7 +38,7 @@ class HieraData
 
     class ConfigNoDatadirInYamlFile < ActiveSupport::TestCase
       test "uses default datadir from puppet" do
-        config = HieraData::Config.new(base_path)
+        config = HieraData::Config.new(base_path.join("hiera.yaml"))
         assert_not_nil config.content["defaults"]
         assert_equal Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH["defaults"]["datadir"], config.content["defaults"]["datadir"]
       end
@@ -50,7 +50,7 @@ class HieraData
 
     class ConfigWithSomeHierarchiesTest < ActiveSupport::TestCase
       test "when only defaults, return the yaml paths" do
-        config = HieraData::Config.new(base_path)
+        config = HieraData::Config.new(base_path.join("hiera.yaml"))
         assert_equal 3, config.hierarchies.size
       end
 
@@ -61,7 +61,7 @@ class HieraData
 
     class ConfigWithEmptyDefaultsTest < ActiveSupport::TestCase
       test "empty defaults get replaced" do
-        config = HieraData::Config.new(base_path)
+        config = HieraData::Config.new(base_path.join("hiera.yaml"))
         assert_not_nil config.content["defaults"]
         assert_equal Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH["defaults"], config.content["defaults"]
       end

--- a/test/models/hiera_data/layer_test.rb
+++ b/test/models/hiera_data/layer_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class HieraData
+  class LayerTest < ActiveSupport::TestCase
+    class NoGlobalLayerPresentTest < ActiveSupport::TestCase
+      def setup
+        @config = Rails.configuration.hdm
+        @original_global_hiera_yaml = @config[:global_hiera_yaml]
+        @config[:global_hiera_yaml] = "/tmp/does/not/exist/hiera.yaml"
+      end
+
+      def teardown
+        @config[:global_hiera_yaml] = @original_global_hiera_yaml
+      end
+
+      test "::self_for does not find a global layer" do
+        layers = HieraData::Layer.for(environment: "development")
+
+        assert_equal 1, layers.size
+        assert_equal "environment", layers.first.name
+      end
+    end
+
+    class GlobalLayerPresentTest < ActiveSupport::TestCase
+      def setup
+        @config = Rails.configuration.hdm
+        @original_global_hiera_yaml = @config[:global_hiera_yaml]
+        @config[:global_hiera_yaml] = Rails.root.join("test/fixtures/files/puppet/global/hiera.yaml").to_s
+      end
+
+      def teardown
+        @config[:global_hiera_yaml] = @original_global_hiera_yaml
+      end
+
+      test "::self_for finds a global layer" do
+        layers = HieraData::Layer.for(environment: "development")
+
+        assert_equal 2, layers.size
+        assert_equal "global", layers.first.name
+      end
+    end
+  end
+end

--- a/test/models/hiera_data_test.rb
+++ b/test/models/hiera_data_test.rb
@@ -64,7 +64,6 @@ class HieraDataTest < ActiveSupport::TestCase
       node = Node.new(hostname: "test.host", environment: "development")
 
       assert_equal 99, hiera.lookup(key: "hdm::integer", facts: node.facts)
-
     end
   end
 end

--- a/test/models/hiera_data_test.rb
+++ b/test/models/hiera_data_test.rb
@@ -2,138 +2,49 @@ require 'test_helper'
 
 class HieraDataTest < ActiveSupport::TestCase
   test "create for environment" do
-    assert HieraData.new('development')
-  end
-
-  test "raise error for unknown environment" do
-    err = assert_raises(HieraData::EnvironmentNotFound) { HieraData.new('unknown') }
-    assert_match("Environment 'unknown' does not exist", err.message)
-  end
-
-  test "#search_key returns key data for all given files" do
-    hiera = HieraData.new('development')
-    expected_result = {
-      "nodes/testhost.yaml" => {file_present: true,  file_writable: true, replaced_from_git: false, key_present: true, value: "hostname: hostname"},
-      "role/hdm_test-development.yaml" => {file_present: false,  file_writable: true, replaced_from_git: false, key_present: false, value: nil},
-      "role/hdm_test.yaml" => {file_present: true, file_writable: true, replaced_from_git: false, key_present: true, value: "hostname: hostname-role"},
-      "zone/internal.yaml" => {file_present: false, file_writable: false, replaced_from_git: false, key_present: false, value: nil },
-      "common.yaml" => {file_present: true,  file_writable: true, replaced_from_git: false, key_present: true, value: "hostname: common::hostname"}
-    }
-    facts = {"fqdn" => "testhost", "role" => "hdm_test", "env" => "development", "zone" => "internal"}
-
-    result = hiera.search_key(hiera.hierarchies.first.name, 'foobar::firstrun::linux_classes', facts:)
-    assert_equal expected_result, result
+    assert HieraData.new(environment: 'development')
   end
 
   test "#all_keys return all keys" do
-    hiera = HieraData.new('development')
+    hiera = HieraData.new(environment: 'development')
     expected_result = [
-        "classes", "foobar::enable_firstrun", "foobar::firstrun::linux_classes", "foobar::postfix::tp::resources_hash", "foobar::time::servers", "foobar::timezone", "hdm::float", "hdm::integer", "noop_mode"
+      "classes", "foobar::enable_firstrun", "foobar::firstrun::linux_classes", "foobar::postfix::tp::resources_hash", "foobar::time::servers", "foobar::timezone", "hdm::float", "hdm::integer", "noop_mode"
     ]
 
     node = Node.new(hostname: "testhost", environment: "development")
-    result = hiera.all_keys(node.facts)
+    result = hiera.all_keys(facts: node.facts)
     assert_equal expected_result, result
   end
 
-  test "#write_key goes fine for the first one" do
-    path = Rails.root.join('test', 'fixtures', 'files', 'puppet', 'environments', 'development', 'data', 'nodes', 'writehost.yaml')
-
-    with_temp_file(path) do
-      expected_hash = {"test_key"=>"true"}
-      hiera = HieraData.new('development')
-      hiera.write_key("Eyaml hierarchy", 'nodes/writehost.yaml', 'test_key', 'true')
-      assert_equal expected_hash, YAML.load_file(path)
-    end
-  end
-
-  test "#write_key goes fine for the second one" do
-    path = Rails.root.join('test', 'fixtures', 'files', 'puppet', 'environments', 'development', 'data', 'nodes', 'writehost.yaml')
-
-    with_temp_file(path) do
-      expected_hash = {"abc" => "def", "test_key"=>"true"}
-      hiera = HieraData.new('development')
-      hiera.write_key("Eyaml hierarchy", 'nodes/writehost.yaml', 'test_key', 'true')
-      hiera.write_key("Eyaml hierarchy", 'nodes/writehost.yaml', 'abc', 'def')
-      assert_equal expected_hash, YAML.load_file(path)
-    end
-  end
-
-  test "#remove_key goes fine" do
-    path = Rails.root.join('test', 'fixtures', 'files', 'puppet', 'environments', 'development', 'data', 'nodes', 'writehost.yaml')
-
-    with_temp_file(path) do
-      expected_hash = {}
-      hiera = HieraData.new('development')
-      hiera.remove_key("Eyaml hierarchy", 'nodes/writehost.yaml', 'test_key')
-      assert_equal expected_hash, YAML.load_file(path)
-    end
-  end
-
-  test "#decrypt_value can decrypt values" do
-    hiera = HieraData.new("eyaml")
-    ciphertext = "ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAe2qPOZxi519fmMyaH47BN1oEnDcluk5ec0jlugSzyInd3v2qirncMYVcAvjg2ckjhWX4h458ZJJuDpT5+ediNG+OQ/BAO+QgjHu7eAR8imjBmeFbjN+dl90y4Lh0S4b/ihpcJ8N9qASWvCePmKafjwFaKNjc6Dws05OQ+G/oBIiXGkXJsE6kbT1qX9DrovHEO6Ve2dANUYmiw1oC8cyqSPi8aBeDdBmZJCQyDrx37QTXf8+b0aVAMG4KPEI1vdoO10ElAsof8Mwx60HkUCCSXRZ2fACp5ODf+hgg9B7Z4eFRxIf4VuqPI+b4pcvPRS/PExI2E99YXIyJz86DD7KPFjA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAgGnfhv3yX43m4aHwqBAB9gBAHgnAZ17HQe3wMCQ2pPuh8]"
-
-    assert_equal "top secret", hiera.decrypt_value("Global data", ciphertext)
-  end
-
-  test "#encrypt_value can encrypt values" do
-    hiera = HieraData.new("eyaml")
-    ciphertext = hiera.encrypt_value("Global data", "top secret")
-
-    assert_match /\AENC\[.+\]\z/, ciphertext
-    assert_no_match /top secret/, ciphertext
-  end
-
-  test "#files_including returns file information for a given key" do
-    hiera = HieraData.new("multiple_hierarchies")
-    expected_result = [
-      {
-        path: "nodes/test.host.yaml",
-        hierarchy_name: "Host specific",
-        hierarchy_backend: :yaml,
-        value: "CET"
-      },
-      {
-        path: "common.yaml",
-        hierarchy_name: "Global data",
-        hierarchy_backend: :yaml,
-        value: "UTC"
-      }
-    ]
-
-    assert_equal expected_result, hiera.files_including("foobar::timezone")
-  end
-
   test "#lookup returns the correct result for the given environment and facts" do
-    hiera = HieraData.new("lookup_tests")
+    hiera = HieraData.new(environment: "lookup_tests")
     node = Node.new(hostname: "lookup.betadots.training", environment: "lookup_tests")
     expected = %w[node role zone common]
 
-    assert_equal expected, hiera.lookup("hdm_duplicates_in_array", facts: node.facts)
+    assert_equal expected, hiera.lookup(key: "hdm_duplicates_in_array", facts: node.facts)
   end
 
   test "#lookup_options_for can use hash syntax" do
-    hiera = HieraData.new("lookup_tests")
+    hiera = HieraData.new(environment: "lookup_tests")
 
-    assert_equal "deep", hiera.lookup_options_for("hash_syntax")
+    assert_equal "deep", hiera.lookup_options_for(key: "hash_syntax")
   end
 
   test "#lookup_options_for favors literal match over regexp" do
-    hiera = HieraData.new("lookup_tests")
+    hiera = HieraData.new(environment: "lookup_tests")
 
-    assert_equal "unique", hiera.lookup_options_for("hdm_duplicates_in_array")
+    assert_equal "unique", hiera.lookup_options_for(key: "hdm_duplicates_in_array")
   end
 
   test "#lookup_options_for uses first regexp match if no literal match possible" do
-    hiera = HieraData.new("lookup_tests")
+    hiera = HieraData.new(environment: "lookup_tests")
 
-    assert_equal "hash", hiera.lookup_options_for("hdm_duplicates_hash")
+    assert_equal "hash", hiera.lookup_options_for(key: "hdm_duplicates_hash")
   end
 
   test "#lookup_options_for defaults to first" do
-    hiera = HieraData.new("lookup_tests")
+    hiera = HieraData.new(environment: "lookup_tests")
 
-    assert_equal "first", hiera.lookup_options_for("hdm_integer")
+    assert_equal "first", hiera.lookup_options_for(key: "hdm_integer")
   end
 end

--- a/test/models/hiera_data_test.rb
+++ b/test/models/hiera_data_test.rb
@@ -47,4 +47,24 @@ class HieraDataTest < ActiveSupport::TestCase
 
     assert_equal "first", hiera.lookup_options_for(key: "hdm_integer")
   end
+
+  class LookupWithMultipleLayersTest < ActiveSupport::TestCase
+    def setup
+      @config = Rails.configuration.hdm
+      @original_global_hiera_yaml = @config[:global_hiera_yaml]
+      @config[:global_hiera_yaml] = Rails.root.join("test/fixtures/files/puppet/global/hiera.yaml").to_s
+    end
+
+    def teardown
+      @config[:global_hiera_yaml] = @original_global_hiera_yaml
+    end
+
+    test "#lookup chooses value from global layer when available" do
+      hiera = HieraData.new(environment: "development")
+      node = Node.new(hostname: "test.host", environment: "development")
+
+      assert_equal 99, hiera.lookup(key: "hdm::integer", facts: node.facts)
+
+    end
+  end
 end

--- a/test/models/hierarchy_test.rb
+++ b/test/models/hierarchy_test.rb
@@ -20,19 +20,19 @@ class HierarchyTest < ActiveSupport::TestCase
     Rails.configuration.hdm["allow_encryption"] = false
     hierarchy = create_hierarchy
 
-    refute hierarchy.encryption_possible?
+    assert_not hierarchy.encryption_possible?
   end
 
   test "#encryption_possible? is false for non-eyaml hierarchies" do
     hierarchy = create_hierarchy(backend: :yaml)
 
-    refute hierarchy.encryption_possible?
+    assert_not hierarchy.encryption_possible?
   end
 
   test "#encryption_possible? is false if hierarchy is not encryptable" do
     hierarchy = create_hierarchy(encryptable: false)
 
-    refute hierarchy.encryption_possible?
+    assert_not hierarchy.encryption_possible?
   end
 
   private
@@ -40,7 +40,7 @@ class HierarchyTest < ActiveSupport::TestCase
   def create_hierarchy(backend: :eyaml, encryptable: true)
     environment = Environment.new(name: "eyaml")
     Hierarchy.new(
-      environment:,
+      layer: environment.environment_layer,
       name: "Global data",
       backend:,
       encryptable:

--- a/test/models/key_test.rb
+++ b/test/models/key_test.rb
@@ -8,44 +8,37 @@ class KeyTest < ActiveSupport::TestCase
 
   test ":all_for puts `lookup_options` first if present" do
     hiera_data = Minitest::Mock.new
-    hiera_data.expect(:all_keys, %w(one lookup_options two), [Hash])
-    HieraData.stub(:new, hiera_data) do
+    hiera_data.expect(:all_keys, %w[one lookup_options two], facts: Hash)
+    @environment.stub(:hiera_data, hiera_data) do
       keys = Key.all_for(@node)
       key_names = keys.map(&:name)
-      assert_equal %w(lookup_options one two), key_names
+      assert_equal %w[lookup_options one two], key_names
     end
   end
 
   test "create key object" do
-    assert Key.new(name: "hdm::integer", environment: @environment)
+    assert Key.new(name: "hdm::integer")
   end
 
-  test "two keys are equal when their environment and name match" do
-    key_one = Key.new(name: "hdm::integer", environment: @environment)
-    key_two = Key.new(name: "hdm::integer", environment: @environment)
+  test "two keys are equal when their name match" do
+    key_one = Key.new(name: "hdm::integer")
+    key_two = Key.new(name: "hdm::integer")
     assert_equal key_one, key_two
   end
 
-  test "two keys are not equal if their environments differ" do
-    hdm_environment = Environment.new(name: "hdm")
-    key_one = Key.new(name: "hdm::integer", environment: @environment)
-    key_two = Key.new(name: "hdm::integer", environment: hdm_environment)
-    assert_not_equal key_one, key_two
-  end
-
   test "two keys are not equal if their names differ" do
-    key_one = Key.new(name: "hdm::integer", environment: @environment)
-    key_two = Key.new(name: "hdm::float", environment: @environment)
+    key_one = Key.new(name: "hdm::integer")
+    key_two = Key.new(name: "hdm::float")
     assert_not_equal key_one, key_two
   end
 
   test "#to_param should return the name" do
-    key = Key.new(name: "hdm::integer", environment: @environment)
+    key = Key.new(name: "hdm::integer")
     assert_equal "hdm::integer", key.to_param
   end
 
   test "#to_s should return the name" do
-    key = Key.new(name: "hdm::integer", environment: @environment)
+    key = Key.new(name: "hdm::integer")
     assert_equal "hdm::integer", key.to_s
   end
 end

--- a/test/models/layer_test.rb
+++ b/test/models/layer_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class LayerTest < ActiveSupport::TestCase
+  test "#hierarchies loads all hierarchies" do
+    environment = Environment.new(name: "development")
+    layer = environment.environment_layer
+    hierarchies = [Hierarchy.new(layer:, name: "test", backend: :yaml)]
+    Hierarchy.stub(:all, hierarchies) do
+      assert_equal hierarchies, layer.hierarchies
+    end
+  end
+end

--- a/test/models/value_test.rb
+++ b/test/models/value_test.rb
@@ -2,28 +2,29 @@ require "test_helper"
 
 class ValueTest < ActiveSupport::TestCase
   setup do
-    @environment = Environment.new(name: "development")
-    @hierarchy = Hierarchy.find(@environment, "Eyaml hierarchy")
+    environment = Environment.new(name: "development")
+    layer = environment.find_layer(name: "environment")
+    @hierarchy = Hierarchy.find(layer:, name: "Eyaml hierarchy")
     @data_file = DataFile.new(hierarchy: @hierarchy, path: "common.yaml")
-    @key = Key.new(name: "test::dummy", environment: @environment)
+    @key = Key.new(name: "test::dummy")
     @value = Value.new(data_file: @data_file, key: @key)
   end
 
   test "#update uses underlying hiera_data object" do
-    hiera_data = Minitest::Mock.new
-    hiera_data.expect(:write_key, true, ["Eyaml hierarchy", "common.yaml", "test::dummy", 23], facts: {})
-    @value.stub(:hiera_data, hiera_data) do
+    hiera_file = Minitest::Mock.new
+    hiera_file.expect(:write_key, true, ["test::dummy", 23])
+    @data_file.stub(:hiera_file, hiera_file) do
       @value.update("23")
     end
-    hiera_data.verify
+    hiera_file.verify
   end
 
   test "#destroy uses underlying hiera_data object" do
-    hiera_data = Minitest::Mock.new
-    hiera_data.expect(:remove_key, true, ["Eyaml hierarchy", "common.yaml", "test::dummy"], facts: {})
-    @value.stub(:hiera_data, hiera_data) do
+    hiera_file = Minitest::Mock.new
+    hiera_file.expect(:remove_key, true, ["common.yaml", "test::dummy"])
+    @data_file.stub(:hiera_file, hiera_file) do
       @value.destroy
     end
-    hiera_data.verify
+    hiera_file.verify
   end
 end


### PR DESCRIPTION
Fixes #330 

This is a larger refactoring of the inner workings of hdm to introduce the concept of different "layers" of hiera configuration. As a first step, it allows to show the "global layer" as well as the environment layer that we always supported.

This also paves the way for #331, as recognizing that there is more than one layer is a prerequisite for that.

Having had to move around and change lots of stuff, I decided to change the architecture a little bit. Until now, the models in `app/models` were strictly divided: Top level classes were mostly "high-level" classes that mimicked rails' ActiveRecord-API where possible. The classes in `app/models/hiera_data` represented "low-level" objects that dealt directly with hiera data, files etc.

The class `HieraData` in `app/models/hiera_data.rb` was used as the central interface between "high-" and "low-level" classes. It was a nice separation in the sense that the high level classes did not have to know anything about hiera internals. And it has served us well for quite some time. But this also meant that `HieraData` was already a very big and complex class. With the addition of layers this was prone to grow out of hand.

Once I decided to break up this structure, it turned out there was a lot of redundant and even some unused code, so I could actually delete a lot of code (always a good thing :slightly_smiling_face:). I am _really_ happy with how everything in the "low-level" classes turned out. The change comes with some additional upsides:

* Everything should be bit faster as a lot less instances of `HieraData` are being created
* We are a lot closer to realizing #84 in case we want to

But as always there are downsides as well. The high-level model classes have become more complex as they need to know more about the hiera internals. They also have more dependencies, because more references to low-level classes need to be passed around. I am not 100% happy with the current state here, as it feels more "bolted on" than actually designed. But I think that #331 and/or #84 may bring more clarity here.

There is also a small detail that changed because of these refactorings and that is not trivial to change back: When doing a key search, hdm now displays the full path to the files instead of a shorter path relative to the `datadir`:

![image](https://github.com/betadots/hdm/assets/68106/5bf594e5-4b20-4438-b643-3aa157c82de6)

I hope that is OK. If not, I think I can find a way to restore the old behavior. It just will not be pretty :grimacing: 

Please note that given how big a change this is, this might introduce some instability. Things that used to work might be broken so give this a good test-drive if possible.

One thing I left out intentionally is the API / integration with foreman. I made sure the behavior of the API did not change, but did nothing more. If we want the global layer in foreman as well, we should create a new issue for that (and decide if that warrants and API v2). But this should probably wait until after #331.