### PR TITLE
Show version number in footer #340

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,22 +34,29 @@
     </main>
 
     <footer class="footer bg-light mt-auto py-4">
-      <div class="container text-center">
-        © <%= Date.today.year %>
-        <a href="https://betadots.de/" class="text-dark">
-          <%= image_tag "betadots.png", alt: "betadots logo", width: "32", height: "32" %>
-          betadots GmbH
-        </a>
-        -
-        Licensed under 
-        <a href="https://github.com/betadots/hdm/blob/main/LICENSE">
-          GNU Affero General Public License v3.0
-        </a>
-        -
-        <a href="https://github.com/betadots/hdm">
-          <%= icon("github") %>
-          Source code
-        </a>
+      <div class="container">
+        <div class="row">
+          <div class="col text-end">
+            <span class="font-monospace"><%= Hdm::VERSION %></span>
+            <br>
+            © <%= Date.today.year %>
+            <a href="https://betadots.de/" class="text-dark">
+              <%= image_tag "betadots.png", alt: "betadots logo", width: "32", height: "32" %>
+              betadots GmbH
+            </a>
+          </div>
+          <div class="col">
+            Licensed under 
+            <a href="https://github.com/betadots/hdm/blob/main/LICENSE">
+              GNU Affero General Public License v3.0
+            </a>
+            <br>
+            <a href="https://github.com/betadots/hdm">
+              <%= icon("github") %>
+              Source code
+            </a>
+          </div>
+        </div>
       </div>
     </footer>
     <%= yield :modals %>

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,0 +1,6 @@
+Hdm::VERSION =
+  if system("git --version >>/dev/null 2>&1")
+    `git describe`.chomp
+  else
+    "unknown"
+  end


### PR DESCRIPTION
This is a very simple attempt to fix #340.

TIL (or more probably re-learned about :grimacing:) `git describe` which already returns something very sensible.

In case your on a tagged version it just returns the tag name. If you are not, it will display the _last_ tag, the number of commits since then and the abbreviated hash of the current commit. So you can see at a glance if someone uses a released version. And if not you can easily find out what state of the repo was used.

So this simply takes the output of `git describe` and displays it in the footer.

I think with this added, the footer includes too much to still have everything on a single line, so I opted for using some layout here:

![image](https://github.com/betadots/hdm/assets/68106/74eec839-ca27-474b-834a-349358902fac)

If you have another idea how to better organize the information, please let me know.