### PR TITLE
Add workflow to automatically create a github release page based on a tag

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,7 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+      - skip-changelog
   categories:
     - title: Breaking Changes 🛠
       labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+---
+on:
+  push:
+    tags:
+      - '*'
+
+name: Release 🚀
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # - name: Set up Ruby
+      #   uses: ruby/setup-ruby@v1
+      #   with:
+      #     bundler-cache: true
+
+      # - name: Prep Environment
+      #   run: |
+      #     bundle config set --local with 'release'
+      #     bundle install
+      #     mkdir -p build
+
+      # - name: Get previous Tag
+      #   id: get-previous-tag
+      #   run: |
+      #     EXCLUDES=$(git describe --abbrev=0 --tags)
+      #     PTAG=$(git describe --abbrev=0 --tags --exclude="${EXCLUDES}")
+      #     echo "previous_tag=${PTAG}" >> "$GITHUB_OUTPUT"
+
+      # - name: Generate Changelog
+      #   env:
+      #     CHANGELOG_GITHUB_TOKEN: ${{ github.token }}
+      #   run: |
+      #     bundle exec github_changelog_generator \
+      #     --user ${{ github.repository_owner }} \
+      #     --project "hdm" \
+      #     --since-tag ${{ steps.get-previous-tag.outputs.previous_tag }} \
+      #     --future-release ${{ github.ref_name }} \
+      #     --output build/changelog.md
+
+      # - name: Create Release
+      #   env:
+      #     GH_TOKEN: ${{ github.token }}
+      #   run: gh release create ${{ github.ref_name }} --notes-file build/changelog.md --title "Release ${{ github.ref_name }}"
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ github.ref_name }} --generate-notes


### PR DESCRIPTION
there is a complicated long way with `github_changelog_generator` or a short way with auto generated release notes via `gh`. the gh honors the `.github/release.yml` and uses the instruction from there to generate the notes.

"the short way" would be the same as we are doing it now manually on each release (if we can remember to do it XD ).