### PR TITLE
Add two very basic system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,16 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  private
+
+  def slim_select(value, from:)
+    select = find("select[name=\"#{from}\"]", visible: false)
+    slim_select_main = select.sibling("div[class=ss-main]")
+    slim_select_main.click
+    option = find("div[class=ss-option]", text: value)
+    option.click
+    page.has_css?("div[class=ss-single]", text: value)
+  end
 end

--- a/test/system/access_nodes_keys_test.rb
+++ b/test/system/access_nodes_keys_test.rb
@@ -1,0 +1,27 @@
+require "application_system_test_case"
+
+class AccessNodesKeysTest < ApplicationSystemTestCase
+  setup do
+    Rails.configuration.hdm[:authentication_disabled] = true
+  end
+
+  teardown do
+    Rails.configuration.hdm[:authentication_disabled] = false
+  end
+
+  test "accessing a key of a node" do
+    visit root_url
+
+    click_on "Show Environments"
+
+    slim_select "development", from: "environment"
+
+    slim_select "testhost (development)", from: "node"
+
+    click_on "hdm::integer"
+
+    click_on "common.yaml"
+
+    assert has_css?("textarea[name=value]", text: "1")
+  end
+end

--- a/test/system/search_key_test.rb
+++ b/test/system/search_key_test.rb
@@ -1,0 +1,29 @@
+require "application_system_test_case"
+
+class SearchKeyTest < ApplicationSystemTestCase
+  setup do
+    Rails.configuration.hdm[:authentication_disabled] = true
+  end
+
+  teardown do
+    Rails.configuration.hdm[:authentication_disabled] = false
+  end
+
+  test "searching for a key" do
+    visit root_url
+
+    click_on "Show Environments"
+
+    slim_select "development", from: "environment"
+
+    fill_in "key", with: "hdm::integer\n"
+
+    assert has_css?("h2", text: "Search Results")
+
+    click_on "Eyaml hierarchy"
+
+    click_on Rails.root.join("test/fixtures/files/puppet/environments/development/data/common.yaml").to_s
+
+    assert has_css?(".accordion-body pre", text: "1")
+  end
+end


### PR DESCRIPTION
Fixes  #367

@rwaffen You might want to have a look. These are the two cases we talked about, but if you look at the code I think you will find that adding additional cases should not be too hard.

The only "real" obstacle here was that I had to create a little helper method for the "slim-select" widget we use for dropdowns. But this is solved now and can be reused easily.