### PR TITLE
Ignore `classifier_data` hierarchies

### DIFF
--- a/app/models/hiera_data/config.rb
+++ b/app/models/hiera_data/config.rb
@@ -29,11 +29,13 @@ class HieraData
     end
 
     def initialize_hierarchies
-      @hierarchies = content['hierarchy'].map do |hierarchy|
-        Hierarchy.new(
-          raw_hash: content['defaults'].merge(hierarchy),
-          base_path: @base_path
-        )
+      @hierarchies = content['hierarchy'].filter_map do |hierarchy|
+        unless hierarchy['data_hash'] == 'classifier_data'
+          Hierarchy.new(
+            raw_hash: content['defaults'].merge(hierarchy),
+            base_path: @base_path
+          )
+        end
       end
     end
   end

--- a/test/fixtures/files/puppet/environments/enterprise/hiera.yaml
+++ b/test/fixtures/files/puppet/environments/enterprise/hiera.yaml
@@ -1,0 +1,6 @@
+---
+version: 5
+
+hierarchy:
+ - name: Classifier Configuration Data
+   data_hash: classifier_data

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -6,6 +6,7 @@ class EnvironmentTest < ActiveSupport::TestCase
       development
       dynamic_datadir
       empty_defaults
+      enterprise
       eyaml
       globs
       hdm

--- a/test/models/hiera_data/config_test.rb
+++ b/test/models/hiera_data/config_test.rb
@@ -70,5 +70,14 @@ class HieraData
         Pathname.new(Rails.configuration.hdm["config_dir"]).join("environments", "empty_defaults")
       end
     end
+
+    class ConfigWithClassifierDataHierarchyTest < ActiveSupport::TestCase
+      test "`classifier_data` hierarchy is being ignored" do
+        base_path = Pathname.new(Rails.configuration.hdm["config_dir"]).join("environments", "enterprise")
+        config = HieraData::Config.new(base_path.join("hiera.yaml"))
+
+        assert_equal [], config.hierarchies
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #489 

This is a very simple "fix". It just ignores `classifier_data` hierarchies if present.

Alternatively we could replace them with empty "dummy" hierarchies, so they are displayed in some way, but always without content. But I am not sure how that would look and work exactly.