### PR TITLE
Add configurable node info section to page headers

### DIFF
--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -1,5 +1,7 @@
 <%= render "select_env_and_node" %>
 
+<%= render "nodes/info" %>
+
 <div class="row mt-4">
   <div class="col-6">
     <%= render "key_list" %>

--- a/app/views/keys/show.html.erb
+++ b/app/views/keys/show.html.erb
@@ -1,5 +1,7 @@
 <%= render "select_env_and_node" %>
 
+<%= render "nodes/info" %>
+
 <div class="row mt-4">
   <div class="col-6">
     <%= render "key_list" %>

--- a/app/views/nodes/_info.html.erb
+++ b/app/views/nodes/_info.html.erb
@@ -1,0 +1,34 @@
+<div class="row my-3">
+  <div class="col-12">
+    <h1><%= @node.name %></h1>
+  </div>
+</div>
+
+<% if Rails.configuration.hdm.node_info %>
+  <div class="row my-3">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-body">
+          <div class="row">
+            <% Rails.configuration.hdm.node_info[0..5].each_slice(2) do |facts| %>
+              <div class="col-4">
+                <dl>
+                  <% facts.each do |fact| %>
+                    <dt><%= fact %></dt>
+                    <dd>
+                      <% if value = @node.facts[fact.sub(/^facts\./, '')] %>
+                        <%= value %>
+                      <% else %>
+                        <span class="text-body-tertiary">&lt;missing&gt;</span>
+                      <% end %>
+                    </dd>
+                  <% end %>
+                </dl>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Possibly fixes #473

This adds a "header" to all node-related pages:

![image](https://github.com/user-attachments/assets/56a8380a-29c3-46e8-a33e-5bf08e6ed071)

The heading with the node's name will now appear on all node-related pages (key list and selected key). The box with the facts will only appear if configured in `config/hdm.yml`.

Note that I opted for `node_info` as a shorter key.

So the information above results from the following configuration:

```yaml
  node_info:
    - facts.fqdn
    - trusted.certname
    - facts.role
    - facts.environment
    - facts.zone
```

Up to 6 facts will be displayed.

Please note that `trusted.certname` really was not available in my test data. *But* I also do not know if it would be available as a value returned by the facts API :man_shrugging: 