### PR TITLE
Enhance ldap configuration

### DIFF
--- a/app/models/ldap.rb
+++ b/app/models/ldap.rb
@@ -10,17 +10,32 @@ class Ldap
     @bind_dn = hdm_ldap_config[:bind_dn]
     @bind_dn_password = hdm_ldap_config[:bind_dn_password]
     @base_dn = hdm_ldap_config[:base_dn]
-    @ldaps = hdm_ldap_config[:ldaps]
+    @username_attribute = hdm_ldap_config[:username_attribute] || "mail"
+    @filter = hdm_ldap_config[:filter]
+    @ssl_mode = hdm_ldap_config[:ssl_mode]
+    @ca_file = hdm_ldap_config[:ca_file]
+    @ssl_verify = hdm_ldap_config.fetch(:ssl_verify, true)
   end
 
-  def authenticate(email, password)
-    ldap.bind_as(filter: "(mail=#{email})", password:) if email.present? && password.present?
+  def authenticate(username, password)
+    return unless username.present? && password.present?
+
+    filter = filter_for(username)
+    ldap.bind_as(filter:, password:)
   end
 
   private
 
+  def filter_for(username)
+    base = "(#{@username_attribute}=#{username})"
+    if @filter.present?
+      "(&#{@filter}#{base})"
+    else
+      base
+    end
+  end
+
   def ldap
-    encryption = @ldaps ? { method: :simple_tls } : nil
     ldap = Net::LDAP.new(
       host: @host,
       port: @port,
@@ -29,5 +44,23 @@ class Ldap
     )
     ldap.authenticate @bind_dn, @bind_dn_password if @bind_dn
     ldap
+  end
+
+  def encryption
+    ssl_method = case @ssl_mode
+                 when "simple"
+                   :simple_tls
+                 when "starttls"
+                   :start_tls
+                 else
+                   return
+                 end
+    {
+      method: ssl_method,
+      tls_options: {
+        ca_file: @ca_file,
+        verify_mode: @ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      }
+    }
   end
 end

--- a/config/hdm.yml.template
+++ b/config/hdm.yml.template
@@ -66,8 +66,13 @@ production:
 #     host: localhost
 #     port: 389
 #     base_dn: "ou=hdm,dc=nodomain"
-#     bind_dn: "cn=admin,dc=nodomain"
-#     bind_dn_password: "openldap"
+#     bind_dn: "cn=admin,dc=nodomain" # Optional
+#     bind_dn_password: "openldap" # Optional
+#     username_attribute: "mail" # Optional, "mail" is the default
+#     filter: "(gid=23)" # Optional
+#     ssl_mode: "simple" # Optional, can also be "starttls"
+#     ca_file: "/etc/ssl/certs/my_ca.pem" # Optional
+#     ssl_verify: true # Optional, defaults to true, only set to false if you really know what you are doing
 
 # Example for SAML SSO authentication
 # production:

--- a/test/models/ldap_test.rb
+++ b/test/models/ldap_test.rb
@@ -2,13 +2,46 @@ require 'test_helper'
 
 class LdapTest < ActiveSupport::TestCase
   test "#authenticate delegates to Net::LDAP's #bind_as" do
-    ldap = Ldap.new
-    net_ldap = Minitest::Mock.new
-    ldap.stub(:ldap, net_ldap) do
-      net_ldap.expect(:bind_as, 42, [], filter: String, password: String)
+    stubbed_ldap do |ldap, net_ldap|
+      filter = "(mail=test@example.com)"
+      net_ldap.expect(:bind_as, 42, [], filter:, password: String)
       authentic = ldap.authenticate("test@example.com", "secret")
       assert_equal authentic, 42
       net_ldap.verify
+    end
+  end
+
+  test "#authenticate allows overwriting the username attribute" do
+    Rails.configuration.hdm[:ldap][:username_attribute] = "uid"
+    stubbed_ldap do |ldap, net_ldap|
+      filter = "(uid=testuser)"
+      net_ldap.expect(:bind_as, 42, [], filter:, password: String)
+      authentic = ldap.authenticate("testuser", "secret")
+      assert_equal authentic, 42
+      net_ldap.verify
+    end
+    Rails.configuration.hdm[:ldap].delete(:username_attribute)
+  end
+
+  test "#authenticate uses an extra filter when given" do
+    Rails.configuration.hdm[:ldap][:filter] = "(gid=23)"
+    stubbed_ldap do |ldap, net_ldap|
+      filter = "(&(gid=23)(mail=test@example.com))"
+      net_ldap.expect(:bind_as, 42, [], filter:, password: String)
+      authentic = ldap.authenticate("test@example.com", "secret")
+      assert_equal authentic, 42
+      net_ldap.verify
+    end
+    Rails.configuration.hdm[:ldap].delete(:filter)
+  end
+
+  private
+
+  def stubbed_ldap
+    ldap = Ldap.new
+    net_ldap = Minitest::Mock.new
+    ldap.stub(:ldap, net_ldap) do
+      yield ldap, net_ldap
     end
   end
 end


### PR DESCRIPTION
This allows setting a different username attribute (e.g. `uid` instead of the default, `mail`).

It also allows specifying an additional filter that is added when trying to authenticate a user. This can be used to e.g. limit ldap authentication to a group (but really anything).

I marked this PR here as draft, because this will only fully work once #598 is merged.

This also includes enhanced options for SSL/TLS. Apart from "normal" (or "simple") ldaps/TLS, this should now also support "STARTTLS". Also a CA file can be specified. Certificate verification has been turned on as a new default, but can optionally be turned off.

Note that this replaces the previously accepted option `ldaps`, which no longer works. I think that should be fine as it was undocumented and probably not used by anyone.

Please see `config/hdm.yml.template` for all the new options.

Note that I only tested against a local LDAP server without TLS. As I only pass the new options through to the `Net::LDAP` library that we use, I think they *should* work, but it would be good to test against a server with (START)TLS enabled and a verifyable certificate.

Fixes #588
Fixes #593