### PR TITLE
Fix leftover old method signature

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -22,7 +22,7 @@ class LookupsController < ApplicationController
   end
 
   def lookup_in_original_environment
-    original_key = Key.new(environment: @node.environment, name: params[:key_id])
+    original_key = Key.new(name: params[:key_id], hiera_data: @node.environment.hiera_data)
     @original_result = original_key.lookup(@node)
   end
 end

--- a/test/integration/diff_environments_test.rb
+++ b/test/integration/diff_environments_test.rb
@@ -12,4 +12,11 @@ class DiffEnvironmentsTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "button#tab-diff-data_file_common-yaml"
   end
+
+  test "performing a lookup in different environment displays diff" do
+    get environment_node_key_lookup_path("hdm", "1m73otky.betadots.training", "testmod::integer")
+
+    assert_response :success
+    assert_select "button#tab-diff-lookup-new_key"
+  end
 end


### PR DESCRIPTION
Fixes #628

Another leftover after a recent(ish) refactoring.

The real problem was that this was not caught by a test. This adds a test that should prevent this code path from falling through the cracks again (and fixes the issue).