### PR TITLE
fix(vagrant): puppet lookup

### DIFF
--- a/vagrant/foreman.sh
+++ b/vagrant/foreman.sh
@@ -54,6 +54,10 @@ echo "Installing puppet modules"
 pushd /etc/puppetlabs/code/environments/production
 sudo /opt/puppetlabs/puppet/bin/r10k puppetfile install -v
 popd
+pushd /etc/puppetlabs/code/environments/feat_23498
+sudo /opt/puppetlabs/puppet/bin/r10k puppetfile install
+popd
+
 
 echo "Preparing custom facts"
 sudo mkdir -p /etc/puppetlabs/facter/facts.d
@@ -70,8 +74,16 @@ sudo /opt/puppetlabs/puppet/bin/puppet config set --section server autosign true
 sudo systemctl restart puppetserver
 sudo /opt/puppetlabs/puppet/bin/puppet agent -t
 
+
+
+
 echo "Installing Foreman HDM"
 sudo foreman-installer --enable-foreman-plugin-hdm --enable-foreman-proxy-plugin-hdm --foreman-proxy-plugin-hdm-hdm-url http://openvox.hdm.workshop.betadots.training:3000
+
+# provides $(puppet lookup) with factes
+# likely got removed by foreman-installer in a previous step
+sudo /opt/puppetlabs/puppet/bin/puppet config set --section main facts_terminus puppetdb
+sudo systemctl restart puppetserver
 
 echo "Uploading facts to PuppetDB"
 sudo /opt/puppetlabs/bin/puppet agent -t


### PR DESCRIPTION
    puppet lookup used to be broken due to missing puppet.conf entry. Further analysis showed that

     * during installation OpenVoxDB ist available
     * foreman-install removes the terminus entry

    puppet.conf-nodeterminus hat to be moved post the foreman installation