### PR TITLE
fix: change response status from unprocessable_entity to unprocessable_content

### DIFF
--- a/app/controllers/ldap_sessions_controller.rb
+++ b/app/controllers/ldap_sessions_controller.rb
@@ -21,7 +21,7 @@ class LdapSessionsController < ApplicationController
       end
     else
       flash.now[:alert] = "Username or password is invalid"
-      render "new", status: :unprocessable_entity
+      render "new", status: :unprocessable_content
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
       end
     else
       flash.now[:alert] = "Email or password is invalid"
-      render "new", status: :unprocessable_entity
+      render "new", status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
         redirect_to @user, notice: 'User was successfully created.'
       end
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to @user, notice: 'User was successfully updated.'
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/test/controllers/ldap_sessions_controller_test.rb
+++ b/test/controllers/ldap_sessions_controller_test.rb
@@ -23,7 +23,7 @@ class LdapSessionsControllerTest < ActionDispatch::IntegrationTest
       post ldap_session_path,
            params: { username: "noboby@example.com", password: "secret" }
 
-      assert_response :unprocessable_entity
+      assert_response :unprocessable_content
     end
   end
 


### PR DESCRIPTION
this is a fix for a Rails style guide introduced in 7.1, next rubocop version will enforce this