### PR TITLE
Hiera: Update Ruby 3.4.8->3.4.9

### DIFF
--- a/vagrant/hdm/production/data/nodes/openvox.hdm.workshop.betadots.training.yaml
+++ b/vagrant/hdm/production/data/nodes/openvox.hdm.workshop.betadots.training.yaml
@@ -6,7 +6,7 @@ classes:
 
 hdm::version: 'main'
 hdm::method: 'rvm'
-hdm::ruby_version: '3.4.8'
+hdm::ruby_version: '3.4.9'
 hdm::disable_authentication: true
 hdm::allow_encryption: true
 hdm::puppetdb_settings:


### PR DESCRIPTION
latest HDM requires Ruby 3.4.9

https://github.com/betadots/hdm/pull/795