### PR TITLE
feat: Manage aliases in yaml + Add options to filter env

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -8,15 +8,35 @@ class Environment < HieraModel
     available_environments = HieraData.environments(
       config_dir: Rails.configuration.hdm.config_dir
     )
+    display_unused_environments = Rails.configuration.hdm.display_unused_environments
+    exclude_environments = Rails.configuration.hdm.exclude_environments
     all_environments = {}
     environments_in_use.sort.each do |e|
       all_environments[e] = { name: e, in_use: true }
     end
     available_environments.sort.each do |e|
-      all_environments[e] ||= { name: e }
-      all_environments[e][:available] = true
+        all_environments[e] ||= { name: e }
+      unless excluded?(e, exclude_environments)
+        all_environments[e][:available] = true
+      else
+        all_environments[e][:available] = false
+      end
     end
-    all_environments.map { |_, attributes| new(**attributes) }
+    if display_unused_environments
+      all_environments.map { |_, attributes| new(**attributes) }
+    else
+      all_environments.select { |_, attributes| attributes[:in_use] }.map { |_, attributes| new(**attributes) }
+    end
+  end
+
+  def self.excluded?(environment_name, exclude_list)
+    exclude_list.any? do |pattern|
+      if pattern.is_a?(Regexp)
+        pattern.match?(environment_name)
+      else
+        pattern == environment_name
+      end
+    end
   end
 
   def self.find(name)

--- a/app/models/hiera_data/config.rb
+++ b/app/models/hiera_data/config.rb
@@ -14,7 +14,7 @@ class HieraData
     def load_content
       defaults = Puppet::Pops::Lookup::HieraConfigV5::DEFAULT_CONFIG_HASH
       config = if File.exist?(@hiera_yaml)
-                 parsed_file = YAML.load_file(@hiera_yaml)
+                 parsed_file = YAML.load_file(@hiera_yaml, aliases: true)
                  unless parsed_file["version"] == 5
                    raise Hdm::Error, "hdm needs your hiera.yaml configuration to be in the version 5 format. Please convert your config file(s) before using hdm."
                  end

--- a/app/models/hiera_data/yaml_file.rb
+++ b/app/models/hiera_data/yaml_file.rb
@@ -34,7 +34,7 @@ class HieraData
     def content
       return nil unless exist?
 
-      @content ||= YAML.load_file(path) || {}
+      @content ||= YAML.load_file(path, aliases: true) || {}
     end
 
     def [](key)

--- a/config/hdm.yml.template
+++ b/config/hdm.yml.template
@@ -26,6 +26,11 @@ production:
   puppet_db:
     server: "http://localhost:8083"
   config_dir: <%= Rails.root.join('test','fixtures','files','puppet') %>
+  #display_unused_environments: false # Optional: hide environments not in use (default: true)
+  #exclude_environments: # Optional: exclude specific environments or patterns
+  #  - old_production
+  #  - !ruby/regexp /^test_.*/
+  #  - !ruby/regexp /.*_backup$/
 
 # Example for PE token authentication
 # production:

--- a/config/initializers/hdm.rb
+++ b/config/initializers/hdm.rb
@@ -1,0 +1,22 @@
+# Ensure hdm configuration has proper defaults
+Rails.application.config.after_initialize do
+  # Ensure display_unused_environments has a default value of true
+  if Rails.configuration.hdm.display_unused_environments.nil?
+    Rails.configuration.hdm.display_unused_environments = true
+  end
+  
+  # Ensure exclude_environments is always an array
+  Rails.configuration.hdm.exclude_environments ||= []
+  
+  # Convert to array if it's not already
+  unless Rails.configuration.hdm.exclude_environments.is_a?(Array)
+    # If it's a hash, extract the keys
+    if Rails.configuration.hdm.exclude_environments.is_a?(Hash)
+      Rails.configuration.hdm.exclude_environments =
+        Rails.configuration.hdm.exclude_environments.keys
+    else
+      # Otherwise, reset to empty array
+      Rails.configuration.hdm.exclude_environments = []
+    end
+  end
+end

--- a/doc/02_Configuration.md
+++ b/doc/02_Configuration.md
@@ -32,6 +32,8 @@ production:
 | hiera_config_file | File name of hiera config file. Default to `hiera.yaml`. |
 | global_hiera_yaml | Optional. Path to the global layer's `hiera.yaml`. |
 | base_module_path | Optional. If you wanna overwrite `basemodulepath` from `puppet.conf`. |
+| display_unused_environments | Optional. Display environments that are available but not in use. Defaults to `true`. Details see [here](#display_unused_environments). |
+| exclude_environments | Optional array. List of environment names or regex patterns to exclude from display. Details see [here](#exclude_environments). |
 | ldap | Optional. Settings for LDAP server for authentication. Details see [here](#ldap). |
 | saml | Optional. Settings for SAML service for authentication. Details see [here](#saml). |
 | git_data | Optional array. Replaces hiera data in the file system with data from a git repo. Details see [here](#git_data). |
@@ -46,6 +48,59 @@ Examples are shown in [hdm.yml.template](../config/hdm.yml.template).
 | pem | With subkeys `key`, `cert`, `ca_file`. Paths to private key, certificate and CA cert for client cert authentication. Use a copy of these files to avoid permission problems. |
 | token | Token to authenticate against `server`. |
 | cacert | Optional. CA cert from OpenVox/Puppet CA to validate cert from `server`. |
+
+### display_unused_environments
+
+Controls whether environments that are available in the file system but not currently in use by PuppetDB should be displayed in HDM.
+
+**Default value:** `true`
+
+**Example:**
+
+```yaml
+production:
+  read_only: true
+  allow_encryption: false
+  puppetdb:
+    server: http://localhost:8080
+  config_dir: /etc/puppetlabs/code
+  display_unused_environments: false  # Hide unused environments
+```
+
+When set to `false`, only environments that are actively in use (reported by PuppetDB) will be displayed. This is useful in production environments where you want to focus only on active environments.
+
+### exclude_environments
+
+An array of environment names or regex patterns to exclude from being displayed in HDM. This is useful for filtering out deprecated, test, or backup environments.
+
+**Default value:** `[]` (empty array)
+
+**Supported formats:**
+- **Exact string match:** Environment name must match exactly
+- **Regex pattern:** Use `!ruby/regexp /pattern/` syntax for pattern matching
+
+**Example:**
+
+```yaml
+production:
+  read_only: true
+  allow_encryption: false
+  puppetdb:
+    server: http://localhost:8080
+  config_dir: /etc/puppetlabs/code
+  exclude_environments:
+    - old_production              # Exact match: exclude "old_production"
+    - deprecated_env              # Exact match: exclude "deprecated_env"
+    - !ruby/regexp /^test_.*/     # Regex: exclude all environments starting with "test_"
+    - !ruby/regexp /.*_backup$/   # Regex: exclude all environments ending with "_backup"
+    - !ruby/regexp /^temp/        # Regex: exclude all environments starting with "temp"
+```
+
+**How it works:**
+- Environments matching any pattern in the list will be excluded from display
+- Both `in_use` and `available` environments are filtered
+- Regex patterns are case-sensitive by default
+- The exclusion is applied before the `display_unused_environments` filter
 
 ### ldap
 


### PR DESCRIPTION
Hi,

We encounter some error when we are using anchor in yaml
```
[153689d4-2dd2-4063-aa62-afa773617f6d] Started GET "/environments/latest/nodes/XXXXXXXXXX/keys" for 62.240.254.33 at 2026-06-16 14:36:23 +0000
[153689d4-2dd2-4063-aa62-afa773617f6d] Processing by KeysController#index as HTML
[153689d4-2dd2-4063-aa62-afa773617f6d]   Parameters: {"environment_id" => "latest", "node_id" => "XXXXXXXXX"}
[153689d4-2dd2-4063-aa62-afa773617f6d] Completed 500 Internal Server Error in 352ms (ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 5.7ms)
[153689d4-2dd2-4063-aa62-afa773617f6d]   
[153689d4-2dd2-4063-aa62-afa773617f6d] Psych::AliasesNotEnabled (Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.):
[153689d4-2dd2-4063-aa62-afa773617f6d]   
```

We enable aliases when the app parse yaml and now it's works 