### PR TITLE
fix: Reject env with empty name

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -4,7 +4,7 @@ class Environment < HieraModel
   attribute :available, :boolean, default: false
 
   def self.all
-    environments_in_use = PuppetDbClient.environments.reject(&:blank?)
+    environments_in_use = PuppetDbClient.environments.compact_blank
     available_environments = HieraData.environments(
       config_dir: Rails.configuration.hdm.config_dir
     )

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -4,7 +4,7 @@ class Environment < HieraModel
   attribute :available, :boolean, default: false
 
   def self.all
-    environments_in_use = PuppetDbClient.environments
+    environments_in_use = PuppetDbClient.environments.reject(&:blank?)
     available_environments = HieraData.environments(
       config_dir: Rails.configuration.hdm.config_dir
     )


### PR DESCRIPTION
It can happen, that PuppetDB returns environments with an empty name.

```command
curl http://localhost:8080/pdb/query/v4/environments | python3 -m json.tool
```

Result:

```json
[
    {
        "name": "production"
    },
    {
        "name": ""
    },
    {
    ...
```

This PR removes environemnts with empty name.